### PR TITLE
Fix cursor not aligning with text #patch

### DIFF
--- a/src/lib/editor/Editor.svelte
+++ b/src/lib/editor/Editor.svelte
@@ -173,6 +173,10 @@
       column = event.position.column;
     });
 
+    document.fonts.ready.then(() => {
+      monaco.editor.remeasureFonts();
+    });
+
     envelope.subscribe((value) => {
       monacoEditor.updateOptions({ readOnly: Boolean(value?.sigs) });
     });


### PR DESCRIPTION
Ref: https://stackoverflow.com/a/64991499/574038

<img width="36" alt="image" src="https://user-images.githubusercontent.com/983924/189875733-8d7216e5-d648-49db-9407-a9aad8b5906d.png">

_Cursor at end of line, not aligning with last character_