### PR TITLE
Remove hint related to templates, which is N/A now #patch

### DIFF
--- a/src/lib/editor/Editor.svelte
+++ b/src/lib/editor/Editor.svelte
@@ -304,7 +304,7 @@
       {#if $editor === ""}
         <p class="m-4">
           <span class="mr-2"><LightbulbIcon /></span><span class="align-middle"
-            >To get started, choose a template from the menu bar.</span
+            >Warnings, errors and tips are shown in this area.</span
           >
         </p>
       {/if}


### PR DESCRIPTION
New default tip:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/983924/195040149-fc35504f-b3ec-4a78-8cbd-5a944220ebe7.png">
