### PR TITLE
Add `signEnabled` component prop

### DIFF
--- a/src/lib/GOBLBuilder.svelte
+++ b/src/lib/GOBLBuilder.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import { editor, editorProblems, envelope, envelopeAndEditorJSON } from "$lib/stores.js";
+  import { editor, editorProblems, envelope, envelopeAndEditorJSON, keypair } from "$lib/stores.js";
   import MenuBar from "./menubar/MenuBar.svelte";
   import Editor from "./editor/Editor.svelte";
   import { isEnvelope } from "./gobl.js";
@@ -21,6 +21,16 @@
   // Problems is an array of Monaco Editor problem markers. It can be used
   // upstream to keep track of the validity of the GOBL document.
   export let problems: EditorProblem[] = [];
+
+  // When enabled, a "Sign" action is available. A client-only keypair is
+  // generated and used for signing GOBL documents.
+  export let signEnabled = true;
+
+  if (signEnabled) {
+    keypair.create().then((keypair) => {
+      console.log("Created keypair.", keypair);
+    });
+  }
 
   // When `data` is updated, update the internal editor and envelope stores.
   // If `data` is JSON and it's a GOBL envelope, parse and store its contents
@@ -65,7 +75,19 @@
 
 <div class="flex flex-col h-full">
   <div class="flex-none">
-    <MenuBar {jsonSchemaURL} on:change on:undo on:redo on:clear on:build on:sign on:validate on:preview on:download />
+    <MenuBar
+      {jsonSchemaURL}
+      {signEnabled}
+      on:change
+      on:undo
+      on:redo
+      on:clear
+      on:build
+      on:sign
+      on:validate
+      on:preview
+      on:download
+    />
   </div>
   <div class="flex-1 overflow-hidden">
     <Editor {jsonSchemaURL} />

--- a/src/lib/actions/Build.svelte
+++ b/src/lib/actions/Build.svelte
@@ -4,7 +4,7 @@
   import * as GOBL from "$lib/gobl.js";
   import { encodeUTF8ToBase64 } from "$lib/encodeUTF8ToBase64.js";
   import { createNotification, Severity } from "$lib/notifications/index.js";
-  import { envelope, editor, keypair, goblError, type GOBLError } from "$lib/stores.js";
+  import { envelope, editor, goblError, type GOBLError } from "$lib/stores.js";
   import { iconButtonClasses } from "$lib/ui/iconButtonClasses.js";
   import Tooltip from "$lib/ui/Tooltip.svelte";
 
@@ -15,10 +15,6 @@
   export let jsonSchemaURL: string;
 
   $: validEditor = (function (): boolean {
-    if (!$keypair) {
-      return false;
-    }
-
     try {
       const parsed = JSON.parse($editor || "");
       if (jsonSchemaURL && parsed.$schema !== jsonSchemaURL) {
@@ -32,7 +28,7 @@
   })();
 
   async function handleBuild() {
-    if (!validEditor || !$keypair) {
+    if (!validEditor) {
       return;
     }
 
@@ -52,7 +48,6 @@
 
       const payload: GOBL.BuildPayload = {
         data: encodeUTF8ToBase64(sendData),
-        privatekey: $keypair.private,
         draft: true,
         envelop: true,
       };

--- a/src/lib/actions/Validate.svelte
+++ b/src/lib/actions/Validate.svelte
@@ -4,7 +4,7 @@
   import * as GOBL from "$lib/gobl.js";
   import { encodeUTF8ToBase64 } from "$lib/encodeUTF8ToBase64.js";
   import { createNotification, Severity } from "$lib/notifications/index.js";
-  import { envelope, envelopeIsDraft, editor, keypair, goblError, type GOBLError } from "$lib/stores.js";
+  import { envelope, envelopeIsSigned, editor, goblError, type GOBLError } from "$lib/stores.js";
   import { iconButtonClasses } from "$lib/ui/iconButtonClasses.js";
   import Tooltip from "$lib/ui/Tooltip.svelte";
 
@@ -15,10 +15,6 @@
   export let jsonSchemaURL: string;
 
   $: validEditor = (function (): boolean {
-    if (!$keypair) {
-      return false;
-    }
-
     try {
       const parsed = JSON.parse($editor || "");
       if (jsonSchemaURL && parsed.$schema !== jsonSchemaURL) {
@@ -32,7 +28,7 @@
   })();
 
   async function handleValidate() {
-    if (!validEditor || $envelopeIsDraft) {
+    if (!validEditor || !$envelopeIsSigned) {
       return;
     }
 
@@ -75,7 +71,7 @@
 </script>
 
 <Tooltip label="Validate a signed GOBL document.">
-  <button on:click={handleValidate} class={iconButtonClasses(!validEditor || $envelopeIsDraft)}>
+  <button on:click={handleValidate} class={iconButtonClasses(!validEditor || !$envelopeIsSigned)}>
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
       <path
         fill-rule="evenodd"

--- a/src/lib/gobl.ts
+++ b/src/lib/gobl.ts
@@ -19,7 +19,6 @@ type BulkRequest =
 export type BuildPayload = {
   template?: string;
   data: string;
-  privatekey: Keypair["private"];
   type?: string;
   draft?: boolean;
   envelop: boolean;

--- a/src/lib/menubar/MenuBar.svelte
+++ b/src/lib/menubar/MenuBar.svelte
@@ -17,6 +17,7 @@
   import Tooltip from "$lib/ui/Tooltip.svelte";
 
   export let jsonSchemaURL: string;
+  export let signEnabled: boolean;
 
   $: envelopeHasSigs = Boolean($envelope?.sigs);
 
@@ -122,7 +123,9 @@
     </div>
     <div class="border-r-2 pr-2 mr-2">
       <Build {jsonSchemaURL} on:build />
-      <Sign {jsonSchemaURL} on:sign />
+      {#if signEnabled}
+        <Sign {jsonSchemaURL} on:sign />
+      {/if}
       <Validate {jsonSchemaURL} on:validate />
     </div>
     <div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -3,16 +3,15 @@ import type * as monaco from "monaco-editor";
 import * as GOBL from "$lib/gobl.js";
 
 function createKeypairStore() {
-  const { subscribe, set } = writable<GOBL.Keypair | null>(null, function start(set) {
-    GOBL.keygen().then((value) => {
-      set(value);
-      console.log("Created keypair.", value);
-    });
-  });
+  const { subscribe, set } = writable<GOBL.Keypair | null>(null);
 
   return {
     subscribe,
-    renew: async () => set(await GOBL.keygen()),
+    create: async () => {
+      const keypair = await GOBL.keygen();
+      set(keypair);
+      return keypair;
+    },
   };
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,6 +33,7 @@
       bind:data
       bind:problems
       {jsonSchemaURL}
+      signEnabled={true}
       on:change={(event) => {
         console.log("Received change event.", event.detail);
       }}


### PR DESCRIPTION
This prop (false by default) allows using GOBL Builder without a sign feature.