### PR TITLE
Corrections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@invopop/gobl-worker": "^0.68.0",
+        "@invopop/gobl-worker": "^0.70.0",
         "@monaco-editor/loader": "^1.3.3",
         "@zerodevx/svelte-toast": "^0.9.5",
         "base-64": "^1.0.0",
@@ -205,9 +205,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@invopop/gobl-worker": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.68.0.tgz",
-      "integrity": "sha512-hKL/NnCtpFSEQNoNCiFSTn8di2Dpfyo+wboXYgbyc6cYvIf1xCjNnDAKiQkJ2h7jYyenJsnv5IxG0Dvc+7zZ8Q=="
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.70.0.tgz",
+      "integrity": "sha512-dziq19/2ufrxp89UN9A9L8/wvxWKxJ8UpE/hunlNniNDU819CLTddGYTRESh5hfUJUUOKYhx93sMObWU3cPddA=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@invopop/gobl-worker": "^0.70.0",
+        "@invopop/gobl-worker": "^0.71.0",
         "@monaco-editor/loader": "^1.3.3",
         "@zerodevx/svelte-toast": "^0.9.5",
         "base-64": "^1.0.0",
@@ -205,9 +205,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@invopop/gobl-worker": {
-      "version": "0.70.0",
-      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.70.0.tgz",
-      "integrity": "sha512-dziq19/2ufrxp89UN9A9L8/wvxWKxJ8UpE/hunlNniNDU819CLTddGYTRESh5hfUJUUOKYhx93sMObWU3cPddA=="
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.71.0.tgz",
+      "integrity": "sha512-tsnQqz35Rg4LBvRPDPGjlsuOCXN38VGNO2XmnTPit7z1+2BWe1aROR6gEi4AuheE/9+o0HpghQCXyoalzFK3RQ=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "vscode-uri": "^3.0.7"
   },
   "dependencies": {
-    "@invopop/gobl-worker": "^0.70.0",
+    "@invopop/gobl-worker": "^0.71.0",
     "@monaco-editor/loader": "^1.3.3",
     "base-64": "^1.0.0",
     "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "vscode-uri": "^3.0.7"
   },
   "dependencies": {
-    "@invopop/gobl-worker": "^0.68.0",
+    "@invopop/gobl-worker": "^0.70.0",
     "@monaco-editor/loader": "^1.3.3",
     "base-64": "^1.0.0",
     "clsx": "^2.0.0",

--- a/src/lib/GOBLBuilder.svelte
+++ b/src/lib/GOBLBuilder.svelte
@@ -229,7 +229,7 @@
   <div>
     <div class="bg-black bg-opacity-70 fixed inset-0 z-40" />
     <Modal title="Correction Options" on:close={() => (openModal = false)}>
-      <DynamicForm model={correctionModel} />
+      <DynamicForm model={correctionModel} on:updated={(event) => (correctionModel = event.detail)} />
     </Modal>
   </div>
 {/if}

--- a/src/lib/GOBLBuilder.svelte
+++ b/src/lib/GOBLBuilder.svelte
@@ -229,7 +229,7 @@
   <div>
     <div class="bg-black bg-opacity-70 fixed inset-0 z-40" />
     <Modal title="Correction Options" on:close={() => (openModal = false)}>
-      <DynamicForm model={correctionModel} on:updated={(event) => (correctionModel = event.detail)} />
+      <DynamicForm model={correctionModel} on:uiRefreshNeeded={(event) => (correctionModel = event.detail)} />
     </Modal>
   </div>
 {/if}

--- a/src/lib/GOBLBuilder.svelte
+++ b/src/lib/GOBLBuilder.svelte
@@ -20,8 +20,10 @@
   import * as actions from "./editor/actions";
   import { schemaUrlForm } from "./editor/form/context/formEditor";
   import type { State } from "./types/editor";
-  import { toast } from "@zerodevx/svelte-toast";
-  import { formatErrors } from "./helpers";
+  import { displayAllErrors } from "./helpers";
+  import Modal from "./ui/Modal.svelte";
+  import DynamicForm from "./editor/form/DynamicForm.svelte";
+  import { generateCorrectOptionsModel, type UIModelField } from "./editor/form/utils/model";
 
   const dispatch = createEventDispatcher();
 
@@ -55,6 +57,8 @@
   export let signEnabled = true;
 
   let editorForm: EditorForm | null = null;
+  let openModal = false;
+  let correctionModel: UIModelField | undefined;
 
   // Whether shows the code or the form editor
   let editorView = localStorage.getItem("editor-view") || "code";
@@ -145,32 +149,20 @@
       return;
     }
 
-    try {
-      const errors = formatErrors(result?.error?.message || "");
-      errors.forEach((e) => {
-        toast.push(e, {
-          duration: 10000,
-          reversed: true,
-          intro: { y: 192 },
-          theme: {
-            "--toastColor": "rgb(75 85 99)",
-            "--toastBackground": "rgb(255 228 230)",
-            "--toastBarBackground": "rgb(225 29 72)",
-          },
-        });
-      });
-    } catch (error) {
-      toast.push(result?.error?.message || "", {
-        duration: 10000,
-        reversed: true,
-        intro: { y: 192 },
-        theme: {
-          "--toastColor": "rgb(75 85 99)",
-          "--toastBackground": "rgb(255 228 230)",
-          "--toastBarBackground": "rgb(225 29 72)",
-        },
-      });
+    displayAllErrors(result?.error?.message || "");
+  };
+
+  export const correct = async () => {
+    const result = await actions.getCorrectionOptionsSchema();
+
+    if (result?.error) {
+      state = "errored";
+      displayAllErrors(result?.error?.message || "");
+      return;
     }
+
+    correctionModel = await generateCorrectOptionsModel(result?.schema || "");
+    openModal = true;
   };
 
   export const sign = async () => {
@@ -232,6 +224,15 @@
     </div>
   </div>
 </div>
+
+{#if openModal}
+  <div>
+    <div class="bg-black bg-opacity-70 fixed inset-0 z-40" />
+    <Modal title="Correction Options" on:close={() => (openModal = false)}>
+      <DynamicForm model={correctionModel} />
+    </Modal>
+  </div>
+{/if}
 
 <SvelteToast />
 

--- a/src/lib/GOBLBuilder.svelte
+++ b/src/lib/GOBLBuilder.svelte
@@ -165,6 +165,24 @@
     openModal = true;
   };
 
+  export const correctWithOtions = async (options: string) => {
+    const result = await actions.correct(options);
+
+    if (result?.error) {
+      state = "errored";
+      displayAllErrors(result?.error?.message || "");
+      return;
+    }
+
+    openModal = false;
+
+    state = "corrected";
+
+    if (!editorForm) return;
+
+    editorForm.recreateFormEditor();
+  };
+
   export const sign = async () => {
     if (!signEnabled) return;
     const result = await actions.sign();
@@ -230,6 +248,10 @@
     <div class="bg-black bg-opacity-70 fixed inset-0 z-40" />
     <Modal title="Correction Options" on:close={() => (openModal = false)}>
       <DynamicForm model={correctionModel} on:uiRefreshNeeded={(event) => (correctionModel = event.detail)} />
+      <button
+        class="border border-black px-6 py-3"
+        on:click={() => correctWithOtions(correctionModel?.root.toJSON() || "")}>Correct</button
+      >
     </Modal>
   </div>
 {/if}

--- a/src/lib/editor/actions.ts
+++ b/src/lib/editor/actions.ts
@@ -121,6 +121,73 @@ export async function validate() {
   }
 }
 
+// Send a request to the GOBL worker to get the adecuate correction fields using
+// editor window contents to read the tax regime.
+export async function getCorrectionOptionsSchema() {
+  if (!get(validEditor)) {
+    return;
+  }
+
+  try {
+    const sendData = getGOBLPayload();
+
+    const payload: GOBL.CorrectPayload = {
+      data: encodeUTF8ToBase64(sendData),
+      schema: true
+    };
+
+    const schema = await GOBL.correct({ payload });
+
+    goblError.set(null);
+
+    return { schema };
+  } catch (e) {
+    const goblErr = GOBL.parseGOBLError(e);
+    goblError.set(goblErr);
+
+    return {
+      schema: null,
+      error: goblErr,
+    };
+  }
+}
+
+// Send a request to the GOBL worker to run the "correct" operation using the current
+// editor window contents and update with the results.
+export async function correct() {
+  if (!get(validEditor)) {
+    return;
+  }
+
+  try {
+    const sendData = getGOBLPayload();
+
+    const payload: GOBL.CorrectPayload = {
+      data: encodeUTF8ToBase64(sendData),
+      options: ''
+    };
+
+    await GOBL.correct({ payload });
+
+    goblError.set(null);
+
+    createNotification({
+      severity: Severity.Success,
+      message: "Document successfully corrected.",
+    });
+
+    return { corrected: true };
+  } catch (e) {
+    const goblErr = GOBL.parseGOBLError(e);
+    goblError.set(goblErr);
+
+    return {
+      corrected: false,
+      error: goblErr,
+    };
+  }
+}
+
 export async function getSchemas() {
   const schemas = await GOBL.schemas();
   return JSON.parse(schemas).list;

--- a/src/lib/editor/actions.ts
+++ b/src/lib/editor/actions.ts
@@ -133,7 +133,7 @@ export async function getCorrectionOptionsSchema() {
 
     const payload: GOBL.CorrectPayload = {
       data: encodeUTF8ToBase64(sendData),
-      schema: true
+      schema: true,
     };
 
     const schema = await GOBL.correct({ payload });
@@ -164,7 +164,7 @@ export async function correct() {
 
     const payload: GOBL.CorrectPayload = {
       data: encodeUTF8ToBase64(sendData),
-      options: ''
+      options: "",
     };
 
     await GOBL.correct({ payload });

--- a/src/lib/editor/actions.ts
+++ b/src/lib/editor/actions.ts
@@ -154,7 +154,7 @@ export async function getCorrectionOptionsSchema() {
 
 // Send a request to the GOBL worker to run the "correct" operation using the current
 // editor window contents and update with the results.
-export async function correct() {
+export async function correct(options: string) {
   if (!get(validEditor)) {
     return;
   }
@@ -164,11 +164,13 @@ export async function correct() {
 
     const payload: GOBL.CorrectPayload = {
       data: encodeUTF8ToBase64(sendData),
-      options: "",
+      options: encodeUTF8ToBase64(options),
     };
 
-    await GOBL.correct({ payload });
+    const rawResult = await GOBL.correct({ payload });
+    const result = JSON.parse(rawResult);
 
+    envelope.set(result);
     goblError.set(null);
 
     createNotification({
@@ -176,13 +178,12 @@ export async function correct() {
       message: "Document successfully corrected.",
     });
 
-    return { corrected: true };
+    return { result };
   } catch (e) {
     const goblErr = GOBL.parseGOBLError(e);
     goblError.set(goblErr);
 
     return {
-      corrected: false,
       error: goblErr,
     };
   }

--- a/src/lib/editor/form/AbstractField.svelte
+++ b/src/lib/editor/form/AbstractField.svelte
@@ -36,7 +36,7 @@
     contextMenuOffset = offset > 0 ? offset : 0;
   }
 
-  const { addField, tryFocusField } = getFormEditorContext() || {};
+  const { addField } = getFormEditorContext() || {};
 
   function handleHover(e: CustomEvent<boolean>) {
     // @note: Prevent undesired hover events on other items while dragging
@@ -69,18 +69,14 @@
     showAddMenu = true;
   }
 
-  function handleAddFieldMenuClose() {
-    showAddMenu = false;
-  }
-
   function focusNextField(nextField = field.getNextFocusableField()) {
     if (!nextField) return;
-    tryFocusField(nextField, 5, 0);
+    nextField.tryFocus(5, 0);
   }
 
   function focusPrevField(prevField = field.getPrevFocusableField()) {
     if (!prevField) return;
-    tryFocusField(prevField, 5, 0);
+    prevField.tryFocus(5, 0);
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -133,7 +129,7 @@
   on:focusout={handleFocusOut}
 >
   <div class="p-0.5 pl-2.5 pr-0" class:pr-2.5={!field.children} class:bg-slate-50={showContextMenu}>
-    <svelte:component this={componentsMap[field.type] || FallbackField} {field} />
+    <svelte:component this={componentsMap[field.type] || FallbackField} {field} on:fieldAdded />
   </div>
   <div class="absolute top-0 right-0">
     <div on:hover={handleHover} class="absolute top-0 left-0 -ml-2.5" class:bg-slate-50={showContextMenu}>
@@ -147,7 +143,7 @@
         style={`margin-top: -${contextMenuOffset}px`}
         bind:this={addMenuRef}
       >
-        <AddFieldMenu {field} on:closeAddFieldMenu={handleAddFieldMenuClose} />
+        <AddFieldMenu on:fieldAdded {field} on:closeAddFieldMenu={() => (showAddMenu = false)} />
       </div>
     {/if}
   </div>

--- a/src/lib/editor/form/AbstractField.svelte
+++ b/src/lib/editor/form/AbstractField.svelte
@@ -139,6 +139,7 @@
       on:fieldDuplicated
       on:fieldMoved
       on:fieldValueUpdated
+      on:fieldKeyUpdated
     />
   </div>
   <div class="absolute top-0 right-0">
@@ -151,6 +152,7 @@
           on:fieldDuplicated
           on:fieldMoved
           on:fieldValueUpdated
+          on:fieldKeyUpdated
         />
       </span>
     </div>

--- a/src/lib/editor/form/AbstractField.svelte
+++ b/src/lib/editor/form/AbstractField.svelte
@@ -129,12 +129,12 @@
   on:focusout={handleFocusOut}
 >
   <div class="p-0.5 pl-2.5 pr-0" class:pr-2.5={!field.children} class:bg-slate-50={showContextMenu}>
-    <svelte:component this={componentsMap[field.type] || FallbackField} {field} on:fieldAdded />
+    <svelte:component this={componentsMap[field.type] || FallbackField} {field} on:fieldAdded on:fieldDeleted />
   </div>
   <div class="absolute top-0 right-0">
     <div on:hover={handleHover} class="absolute top-0 left-0 -ml-2.5" class:bg-slate-50={showContextMenu}>
       <span class:invisible={($envelopeIsSigned || !field.is.root) && !showContextMenu}>
-        <FieldContextMenu {field} on:addField={handleAddField} />
+        <FieldContextMenu {field} on:addField={handleAddField} on:fieldDeleted />
       </span>
     </div>
     {#if showAddMenu}

--- a/src/lib/editor/form/AbstractField.svelte
+++ b/src/lib/editor/form/AbstractField.svelte
@@ -129,12 +129,18 @@
   on:focusout={handleFocusOut}
 >
   <div class="p-0.5 pl-2.5 pr-0" class:pr-2.5={!field.children} class:bg-slate-50={showContextMenu}>
-    <svelte:component this={componentsMap[field.type] || FallbackField} {field} on:fieldAdded on:fieldDeleted />
+    <svelte:component
+      this={componentsMap[field.type] || FallbackField}
+      {field}
+      on:fieldAdded
+      on:fieldDeleted
+      on:fieldDuplicated
+    />
   </div>
   <div class="absolute top-0 right-0">
     <div on:hover={handleHover} class="absolute top-0 left-0 -ml-2.5" class:bg-slate-50={showContextMenu}>
       <span class:invisible={($envelopeIsSigned || !field.is.root) && !showContextMenu}>
-        <FieldContextMenu {field} on:addField={handleAddField} on:fieldDeleted />
+        <FieldContextMenu {field} on:addField={handleAddField} on:fieldDeleted on:fieldDuplicated />
       </span>
     </div>
     {#if showAddMenu}

--- a/src/lib/editor/form/AbstractField.svelte
+++ b/src/lib/editor/form/AbstractField.svelte
@@ -138,12 +138,20 @@
       on:fieldDeleted
       on:fieldDuplicated
       on:fieldMoved
+      on:fieldValueUpdated
     />
   </div>
   <div class="absolute top-0 right-0">
     <div on:hover={handleHover} class="absolute top-0 left-0 -ml-2.5" class:bg-slate-50={showContextMenu}>
       <span class:invisible={($envelopeIsSigned || !field.is.root) && !showContextMenu}>
-        <FieldContextMenu {field} on:addField={handleAddField} on:fieldDeleted on:fieldDuplicated on:fieldMoved />
+        <FieldContextMenu
+          {field}
+          on:addField={handleAddField}
+          on:fieldDeleted
+          on:fieldDuplicated
+          on:fieldMoved
+          on:fieldValueUpdated
+        />
       </span>
     </div>
     {#if showAddMenu}

--- a/src/lib/editor/form/AddFieldMenu.svelte
+++ b/src/lib/editor/form/AddFieldMenu.svelte
@@ -56,7 +56,7 @@
 
   function handleAddField(parentField: UIModelField, option: SchemaOption) {
     handleCloseMenu();
-    const newField = parentField.addChildField(option, undefined);
+    const newField = parentField.addChildField(option);
     newField?.tryFocus();
     dispatch("fieldAdded", newField);
   }

--- a/src/lib/editor/form/AddFieldMenu.svelte
+++ b/src/lib/editor/form/AddFieldMenu.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { fade } from "svelte/transition";
   import hover from "./action/hover.js";
-  import { getFormEditorContext } from "./context/formEditor.js";
   import { createEventDispatcher } from "svelte";
   import { sleep } from "./utils/sleep.js";
   import type { SchemaOption, UIModelField } from "./utils/model.js";
@@ -14,8 +13,6 @@
   let filterStr = "";
 
   const dispatch = createEventDispatcher();
-
-  const { addField } = getFormEditorContext() || {};
 
   function filterOptions(options: SchemaOption[], filterStr: string) {
     return options
@@ -59,7 +56,9 @@
 
   function handleAddField(parentField: UIModelField, option: SchemaOption) {
     handleCloseMenu();
-    addField(parentField, option);
+    const newField = parentField.addChildField(option, undefined);
+    newField?.tryFocus();
+    dispatch("fieldAdded", newField);
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/src/lib/editor/form/ArrayField.svelte
+++ b/src/lib/editor/form/ArrayField.svelte
@@ -9,6 +9,14 @@
   $: props = $$props as PropsInterface;
 </script>
 
-<ObjectField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved on:fieldValueUpdated>
+<ObjectField
+  {...props}
+  on:fieldAdded
+  on:fieldDeleted
+  on:fieldDuplicated
+  on:fieldMoved
+  on:fieldValueUpdated
+  on:fieldKeyUpdated
+>
   <slot />
 </ObjectField>

--- a/src/lib/editor/form/ArrayField.svelte
+++ b/src/lib/editor/form/ArrayField.svelte
@@ -9,6 +9,6 @@
   $: props = $$props as PropsInterface;
 </script>
 
-<ObjectField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved>
+<ObjectField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved on:fieldValueUpdated>
   <slot />
 </ObjectField>

--- a/src/lib/editor/form/ArrayField.svelte
+++ b/src/lib/editor/form/ArrayField.svelte
@@ -9,6 +9,6 @@
   $: props = $$props as PropsInterface;
 </script>
 
-<ObjectField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated>
+<ObjectField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved>
   <slot />
 </ObjectField>

--- a/src/lib/editor/form/ArrayField.svelte
+++ b/src/lib/editor/form/ArrayField.svelte
@@ -9,6 +9,6 @@
   $: props = $$props as PropsInterface;
 </script>
 
-<ObjectField {...props} on:fieldAdded>
+<ObjectField {...props} on:fieldAdded on:fieldDeleted>
   <slot />
 </ObjectField>

--- a/src/lib/editor/form/ArrayField.svelte
+++ b/src/lib/editor/form/ArrayField.svelte
@@ -9,6 +9,6 @@
   $: props = $$props as PropsInterface;
 </script>
 
-<ObjectField {...props} on:fieldAdded on:fieldDeleted>
+<ObjectField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated>
   <slot />
 </ObjectField>

--- a/src/lib/editor/form/ArrayField.svelte
+++ b/src/lib/editor/form/ArrayField.svelte
@@ -9,6 +9,6 @@
   $: props = $$props as PropsInterface;
 </script>
 
-<ObjectField {...props}>
+<ObjectField {...props} on:fieldAdded>
   <slot />
 </ObjectField>

--- a/src/lib/editor/form/BooleanField.svelte
+++ b/src/lib/editor/form/BooleanField.svelte
@@ -16,5 +16,5 @@
   }
 </script>
 
-<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated />
+<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated on:fieldKeyUpdated />
 <slot />

--- a/src/lib/editor/form/BooleanField.svelte
+++ b/src/lib/editor/form/BooleanField.svelte
@@ -16,5 +16,5 @@
   }
 </script>
 
-<LeafField {...props} parseValue={handleParseValue} />
+<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated />
 <slot />

--- a/src/lib/editor/form/DynamicForm.svelte
+++ b/src/lib/editor/form/DynamicForm.svelte
@@ -9,14 +9,6 @@
   export let showSchemaField = false;
   export let isEmptySchema = false;
   export let model: UIModelRootField | UIModelField | undefined = undefined;
-
-  function handleFieldAdded() {
-    dispatch("updated", model);
-  }
-
-  function handleFieldDeleted() {
-    dispatch("updated", model);
-  }
 </script>
 
 <div class="h-full overflow-y-auto overflow-x-hidden bg-color1">
@@ -25,7 +17,12 @@
       {#if showSchemaField}
         <SchemaField {isEmptySchema} />
       {:else if model}
-        <AbstractField field={model} on:fieldAdded={handleFieldAdded} on:fieldDeleted={handleFieldDeleted} />
+        <AbstractField
+          field={model}
+          on:fieldAdded={() => dispatch("updated", model)}
+          on:fieldDeleted={() => dispatch("updated", model)}
+          on:fieldDuplicated={() => dispatch("updated", model)}
+        />
       {/if}
     </div>
   </div>

--- a/src/lib/editor/form/DynamicForm.svelte
+++ b/src/lib/editor/form/DynamicForm.svelte
@@ -22,6 +22,7 @@
           on:fieldAdded={() => dispatch("updated", model)}
           on:fieldDeleted={() => dispatch("updated", model)}
           on:fieldDuplicated={() => dispatch("updated", model)}
+          on:fieldMoved={() => dispatch("updated", model)}
         />
       {/if}
     </div>

--- a/src/lib/editor/form/DynamicForm.svelte
+++ b/src/lib/editor/form/DynamicForm.svelte
@@ -19,11 +19,24 @@
       {:else if model}
         <AbstractField
           field={model}
-          on:fieldAdded={() => dispatch("updated", model)}
-          on:fieldDeleted={() => dispatch("updated", model)}
-          on:fieldDuplicated={() => dispatch("updated", model)}
-          on:fieldMoved={() => dispatch("updated", model)}
-          on:fieldValueUpdated={() => dispatch("updated", model)}
+          on:fieldAdded={(event) => {
+            dispatch("uiRefreshNeeded", model);
+            dispatch("fieldAdded", event);
+          }}
+          on:fieldDeleted={(event) => {
+            dispatch("uiRefreshNeeded", model);
+            dispatch("fieldDeleted", event);
+          }}
+          on:fieldDuplicated={(event) => {
+            dispatch("uiRefreshNeeded", model);
+            dispatch("fieldDuplicated", event);
+          }}
+          on:fieldMoved={(event) => {
+            dispatch("uiRefreshNeeded", model);
+            dispatch("fieldMoved", event);
+          }}
+          on:fieldValueUpdated
+          on:fieldKeyUpdated
         />
       {/if}
     </div>

--- a/src/lib/editor/form/DynamicForm.svelte
+++ b/src/lib/editor/form/DynamicForm.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import SchemaField from "./SchemaField.svelte";
+  import AbstractField from "./AbstractField.svelte";
+  import type { UIModelRootField, UIModelField } from "./utils/model";
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  export let showSchemaField = false;
+  export let isEmptySchema = false;
+  export let model: UIModelRootField | UIModelField | undefined = undefined;
+
+  function handleFieldAdded() {
+    dispatch("updated", model);
+  }
+</script>
+
+<div class="h-full overflow-y-auto overflow-x-hidden bg-color1">
+  <div class="flex justify-center px-16 py-8 pb-40 text-sm">
+    <div class="w-full max-w-[536px]">
+      {#if showSchemaField}
+        <SchemaField {isEmptySchema} />
+      {:else if model}
+        <AbstractField field={model} on:fieldAdded={handleFieldAdded} />
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/lib/editor/form/DynamicForm.svelte
+++ b/src/lib/editor/form/DynamicForm.svelte
@@ -23,6 +23,7 @@
           on:fieldDeleted={() => dispatch("updated", model)}
           on:fieldDuplicated={() => dispatch("updated", model)}
           on:fieldMoved={() => dispatch("updated", model)}
+          on:fieldValueUpdated={() => dispatch("updated", model)}
         />
       {/if}
     </div>

--- a/src/lib/editor/form/DynamicForm.svelte
+++ b/src/lib/editor/form/DynamicForm.svelte
@@ -13,6 +13,10 @@
   function handleFieldAdded() {
     dispatch("updated", model);
   }
+
+  function handleFieldDeleted() {
+    dispatch("updated", model);
+  }
 </script>
 
 <div class="h-full overflow-y-auto overflow-x-hidden bg-color1">
@@ -21,7 +25,7 @@
       {#if showSchemaField}
         <SchemaField {isEmptySchema} />
       {:else if model}
-        <AbstractField field={model} on:fieldAdded={handleFieldAdded} />
+        <AbstractField field={model} on:fieldAdded={handleFieldAdded} on:fieldDeleted={handleFieldDeleted} />
       {/if}
     </div>
   </div>

--- a/src/lib/editor/form/EditableField.svelte
+++ b/src/lib/editor/form/EditableField.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import type { SchemaValue } from "$lib/editor/form/utils/schema.js";
   import type { UIModelField } from "$lib/editor/form/utils/model.js";
-  import { getFormEditorContext } from "./context/formEditor.js";
   import EditableSelectField from "./EditableSelectField.svelte";
   import EditableTextField from "./EditableTextField.svelte";
   import EditableDateField from "./EditableDateField.svelte";
   import FieldError from "./FieldError.svelte";
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
 
   export let parseValue: (value: SchemaValue) => SchemaValue;
   export let field: UIModelField<string>;
@@ -13,13 +15,13 @@
   let error = "";
   $: showError = Boolean(error);
 
-  const { changeFieldValue } = getFormEditorContext() || {};
-
   function handleEdit(e: CustomEvent<SchemaValue>) {
     const value = e.detail;
 
     const parsedValue = parseValue(value);
-    changeFieldValue(field, parsedValue);
+    const result = field.setValue(parsedValue as string);
+    if (!result) return;
+    dispatch("fieldValueUpdated", field);
   }
 
   function validateField(e: CustomEvent<SchemaValue>) {

--- a/src/lib/editor/form/EditableField.svelte
+++ b/src/lib/editor/form/EditableField.svelte
@@ -24,12 +24,16 @@
     dispatch("fieldValueUpdated", field);
   }
 
+  function isEmpty(value: SchemaValue) {
+    return value === null || value === "" || value === undefined;
+  }
+
   function validateField(e: CustomEvent<SchemaValue>) {
     const value = e.detail;
     const parsedValue = parseValue(value);
 
     if (field.is.required) {
-      error = parsedValue ? "" : "Required field";
+      error = isEmpty(parsedValue) ? "Required field" : "";
       return;
     }
 

--- a/src/lib/editor/form/EditableFieldKey.svelte
+++ b/src/lib/editor/form/EditableFieldKey.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import type { SchemaValue } from "$lib/editor/form/utils/schema.js";
   import type { UIModelField } from "$lib/editor/form/utils/model.js";
-  import { getFormEditorContext } from "./context/formEditor.js";
   import EditableTextField from "./EditableTextField.svelte";
   import { Icon, PencilSquare } from "svelte-hero-icons";
+  import { createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
 
   export let parseKey: (key: SchemaValue) => string = (key) => (key + "").toLowerCase().replace(/[^a-z0-9_-]/g, "");
   export let field: UIModelField<string>;
 
   let inputValue: SchemaValue = field.key;
-
-  const { changeFieldKey } = getFormEditorContext() || {};
 
   function handleEdit(e: CustomEvent<SchemaValue>) {
     const value = e.detail;
@@ -23,7 +23,9 @@
     if (!inputValue) return;
 
     const parsedKey = parseKey(inputValue);
-    changeFieldKey(field, parsedKey);
+    const result = field.setKey(parsedKey);
+    if (!result) return;
+    dispatch("fieldKeyUpdated", field);
   }
 </script>
 

--- a/src/lib/editor/form/EditorForm.svelte
+++ b/src/lib/editor/form/EditorForm.svelte
@@ -55,10 +55,14 @@
   }
 
   function handleFormUpdated(event: CustomEvent) {
+    handleUpdateEditor(event);
+    recreateFormEditor();
+  }
+
+  function handleUpdateEditor(event: CustomEvent) {
     const model = event.detail;
     const value = model.root.toJSON();
     editor.set({ value, updatedAt: Date.now() });
-    recreateFormEditor();
   }
 </script>
 
@@ -66,5 +70,12 @@
 {#if $recreatingUiModel}
   <div class="text-center mt-6 w-full flex items-center justify-center"><LoadingIcon /></div>
 {:else}
-  <DynamicForm model={$uiModel.value} {showSchemaField} {isEmptySchema} on:updated={handleFormUpdated} />
+  <DynamicForm
+    model={$uiModel.value}
+    {showSchemaField}
+    {isEmptySchema}
+    on:uiRefreshNeeded={handleFormUpdated}
+    on:fieldKeyUpdated={handleUpdateEditor}
+    on:fieldValueUpdated={handleUpdateEditor}
+  />
 {/if}

--- a/src/lib/editor/form/EditorForm.svelte
+++ b/src/lib/editor/form/EditorForm.svelte
@@ -5,11 +5,10 @@
     recreatingUiModel,
     schemaUrlForm,
   } from "./context/formEditor.js";
-  import { currentEditorSchema, jsonSchema } from "$lib/editor/stores.js";
-  import AbstractField from "./AbstractField.svelte";
+  import { currentEditorSchema, editor, jsonSchema } from "$lib/editor/stores.js";
   import LoadingIcon from "$lib/ui/LoadingIcon.svelte";
   import { getSchemas } from "../actions.js";
-  import SchemaField from "./SchemaField.svelte";
+  import DynamicForm from "./DynamicForm.svelte";
 
   createFormEditorContext(schemaUrlForm);
 
@@ -54,21 +53,18 @@
     schemaUrlForm.set(null);
     schemaUrlForm.set($jsonSchema);
   }
+
+  function handleFormUpdated(event: CustomEvent) {
+    const model = event.detail;
+    const value = model.root.toJSON();
+    editor.set({ value, updatedAt: Date.now() });
+    recreateFormEditor();
+  }
 </script>
 
 <svelte:window on:keydown={handleKeyDown} />
 {#if $recreatingUiModel}
   <div class="text-center mt-6 w-full flex items-center justify-center"><LoadingIcon /></div>
 {:else}
-  <div class="h-full overflow-y-auto overflow-x-hidden bg-color1">
-    <div class="flex justify-center px-16 py-8 pb-40 text-sm">
-      <div class="w-full max-w-[536px]">
-        {#if showSchemaField}
-          <SchemaField {isEmptySchema} />
-        {:else if $uiModel.value}
-          <AbstractField field={$uiModel.value} />
-        {/if}
-      </div>
-    </div>
-  </div>
+  <DynamicForm model={$uiModel.value} {showSchemaField} {isEmptySchema} on:updated={handleFormUpdated} />
 {/if}

--- a/src/lib/editor/form/FieldContextMenu.svelte
+++ b/src/lib/editor/form/FieldContextMenu.svelte
@@ -9,7 +9,7 @@
 
   function handleRemove() {
     field.delete();
-    dispatch("fieldDeleted");
+    dispatch("fieldDeleted", field);
   }
 
   function handleDuplicate() {

--- a/src/lib/editor/form/FieldContextMenu.svelte
+++ b/src/lib/editor/form/FieldContextMenu.svelte
@@ -4,17 +4,23 @@
   import FieldButtons from "$lib/editor/form/FieldButtons.svelte";
   import type { UIModelField } from "./utils/model.js";
 
-  const { deleteField, duplicateField, moveField } = getFormEditorContext() || {};
+  // const { deleteField, duplicateField, moveField } = getFormEditorContext() || {};
+  const { duplicateField, moveField } = getFormEditorContext() || {};
   const dispatch = createEventDispatcher();
 
   export let field: UIModelField;
+
+  function handleRemove() {
+    field.delete();
+    dispatch("fieldDeleted");
+  }
 </script>
 
 <FieldButtons
   {field}
   on:add={() => dispatch("addField")}
   on:duplicate={() => duplicateField(field)}
-  on:remove={() => deleteField(field)}
+  on:remove={handleRemove}
   on:moveUp={() => moveField(field, "up")}
   on:moveDown={() => moveField(field, "down")}
 />

--- a/src/lib/editor/form/FieldContextMenu.svelte
+++ b/src/lib/editor/form/FieldContextMenu.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { getFormEditorContext } from "./context/formEditor.js";
   import { createEventDispatcher } from "svelte";
   import FieldButtons from "$lib/editor/form/FieldButtons.svelte";
   import type { UIModelField } from "./utils/model.js";
 
-  const { moveField } = getFormEditorContext() || {};
   const dispatch = createEventDispatcher();
 
   export let field: UIModelField;
@@ -25,6 +23,16 @@
     focusField.tryFocus();
     dispatch("fieldDuplicated", newField);
   }
+
+  function handleModeFieldUp() {
+    field.move("up");
+    dispatch("fieldMoved", field);
+  }
+
+  function handleModeFieldDown() {
+    field.move("down");
+    dispatch("fieldMoved", field);
+  }
 </script>
 
 <FieldButtons
@@ -32,6 +40,6 @@
   on:add={() => dispatch("addField")}
   on:duplicate={handleDuplicate}
   on:remove={handleRemove}
-  on:moveUp={() => moveField(field, "up")}
-  on:moveDown={() => moveField(field, "down")}
+  on:moveUp={handleModeFieldUp}
+  on:moveDown={handleModeFieldDown}
 />

--- a/src/lib/editor/form/FieldContextMenu.svelte
+++ b/src/lib/editor/form/FieldContextMenu.svelte
@@ -4,8 +4,7 @@
   import FieldButtons from "$lib/editor/form/FieldButtons.svelte";
   import type { UIModelField } from "./utils/model.js";
 
-  // const { deleteField, duplicateField, moveField } = getFormEditorContext() || {};
-  const { duplicateField, moveField } = getFormEditorContext() || {};
+  const { moveField } = getFormEditorContext() || {};
   const dispatch = createEventDispatcher();
 
   export let field: UIModelField;
@@ -14,12 +13,24 @@
     field.delete();
     dispatch("fieldDeleted");
   }
+
+  function handleDuplicate() {
+    const newField = field.duplicate();
+    if (!newField) return;
+
+    const focusField = newField.getFirstFocusableChild();
+
+    if (!focusField) return;
+
+    focusField.tryFocus();
+    dispatch("fieldDuplicated", newField);
+  }
 </script>
 
 <FieldButtons
   {field}
   on:add={() => dispatch("addField")}
-  on:duplicate={() => duplicateField(field)}
+  on:duplicate={handleDuplicate}
   on:remove={handleRemove}
   on:moveUp={() => moveField(field, "up")}
   on:moveDown={() => moveField(field, "down")}

--- a/src/lib/editor/form/IntegerField.svelte
+++ b/src/lib/editor/form/IntegerField.svelte
@@ -16,5 +16,5 @@
   }
 </script>
 
-<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated />
+<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated on:fieldKeyUpdated />
 <slot />

--- a/src/lib/editor/form/IntegerField.svelte
+++ b/src/lib/editor/form/IntegerField.svelte
@@ -16,5 +16,5 @@
   }
 </script>
 
-<LeafField {...props} parseValue={handleParseValue} />
+<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated />
 <slot />

--- a/src/lib/editor/form/LeafField.svelte
+++ b/src/lib/editor/form/LeafField.svelte
@@ -23,6 +23,6 @@
     {/if}
   </div>
   <div class:pointer-events-none={$envelopeIsSigned} class="flex items-center justify-start w-[248px]">
-    <EditableField {field} {parseValue} />
+    <EditableField {field} {parseValue} on:fieldValueUpdated />
   </div>
 </div>

--- a/src/lib/editor/form/LeafField.svelte
+++ b/src/lib/editor/form/LeafField.svelte
@@ -17,12 +17,12 @@
 <div class="flex items-stretch justify-between w-full gap-2" title={label}>
   <div class:pointer-events-none={$envelopeIsSigned} class="flex items-center justify-start">
     {#if field.is.editableKey}
-      <EditableFieldKey {field} {parseKey} />
+      <EditableFieldKey {field} {parseKey} on:fieldKeyUpdated />
     {:else}
       <FieldTitle {field} />
     {/if}
   </div>
   <div class:pointer-events-none={$envelopeIsSigned} class="flex items-center justify-start w-[248px]">
-    <EditableField {field} {parseValue} on:fieldValueUpdated />
+    <EditableField {field} {parseValue} on:fieldValueUpdated on:fieldKeyUpdated />
   </div>
 </div>

--- a/src/lib/editor/form/ObjectField.svelte
+++ b/src/lib/editor/form/ObjectField.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if field.is.root}
-  <RootField {...props} on:fieldAdded />
+  <RootField {...props} on:fieldAdded on:fieldDeleted />
 {:else}
   <div id={field.id} title={label}>
     <button class="flex items-center justify-start cursor-pointer h-8" on:click={handleExpandChange}>

--- a/src/lib/editor/form/ObjectField.svelte
+++ b/src/lib/editor/form/ObjectField.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if field.is.root}
-  <RootField {...props} on:fieldAdded on:fieldDeleted />
+  <RootField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated />
 {:else}
   <div id={field.id} title={label}>
     <button class="flex items-center justify-start cursor-pointer h-8" on:click={handleExpandChange}>
@@ -44,7 +44,7 @@
       on:focusin|capture={handleFocusInner}
     >
       {#each children as childField (childField.id)}
-        <AbstractField field={childField} on:fieldAdded />
+        <AbstractField field={childField} on:fieldAdded on:fieldDeleted on:fieldDuplicated />
       {/each}
     </div>
     <slot />

--- a/src/lib/editor/form/ObjectField.svelte
+++ b/src/lib/editor/form/ObjectField.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if field.is.root}
-  <RootField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved />
+  <RootField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved on:fieldValueUpdated />
 {:else}
   <div id={field.id} title={label}>
     <button class="flex items-center justify-start cursor-pointer h-8" on:click={handleExpandChange}>
@@ -44,7 +44,14 @@
       on:focusin|capture={handleFocusInner}
     >
       {#each children as childField (childField.id)}
-        <AbstractField field={childField} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved />
+        <AbstractField
+          field={childField}
+          on:fieldAdded
+          on:fieldDeleted
+          on:fieldDuplicated
+          on:fieldMoved
+          on:fieldValueUpdated
+        />
       {/each}
     </div>
     <slot />

--- a/src/lib/editor/form/ObjectField.svelte
+++ b/src/lib/editor/form/ObjectField.svelte
@@ -30,7 +30,15 @@
 </script>
 
 {#if field.is.root}
-  <RootField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved on:fieldValueUpdated />
+  <RootField
+    {...props}
+    on:fieldAdded
+    on:fieldDeleted
+    on:fieldDuplicated
+    on:fieldMoved
+    on:fieldValueUpdated
+    on:fieldKeyUpdated
+  />
 {:else}
   <div id={field.id} title={label}>
     <button class="flex items-center justify-start cursor-pointer h-8" on:click={handleExpandChange}>
@@ -51,6 +59,7 @@
           on:fieldDuplicated
           on:fieldMoved
           on:fieldValueUpdated
+          on:fieldKeyUpdated
         />
       {/each}
     </div>

--- a/src/lib/editor/form/ObjectField.svelte
+++ b/src/lib/editor/form/ObjectField.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if field.is.root}
-  <RootField {...props} />
+  <RootField {...props} on:fieldAdded />
 {:else}
   <div id={field.id} title={label}>
     <button class="flex items-center justify-start cursor-pointer h-8" on:click={handleExpandChange}>
@@ -44,7 +44,7 @@
       on:focusin|capture={handleFocusInner}
     >
       {#each children as childField (childField.id)}
-        <AbstractField field={childField} />
+        <AbstractField field={childField} on:fieldAdded />
       {/each}
     </div>
     <slot />

--- a/src/lib/editor/form/ObjectField.svelte
+++ b/src/lib/editor/form/ObjectField.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#if field.is.root}
-  <RootField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated />
+  <RootField {...props} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved />
 {:else}
   <div id={field.id} title={label}>
     <button class="flex items-center justify-start cursor-pointer h-8" on:click={handleExpandChange}>
@@ -44,7 +44,7 @@
       on:focusin|capture={handleFocusInner}
     >
       {#each children as childField (childField.id)}
-        <AbstractField field={childField} on:fieldAdded on:fieldDeleted on:fieldDuplicated />
+        <AbstractField field={childField} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved />
       {/each}
     </div>
     <slot />

--- a/src/lib/editor/form/RootField.svelte
+++ b/src/lib/editor/form/RootField.svelte
@@ -17,6 +17,6 @@
     <h1 class="text-sm capitalize text-grey-4 font-bold p-2">{title}</h1>
   {/if}
   {#each children || emptyChildren as field (field.id)}
-    <AbstractField {field} on:fieldAdded on:fieldDeleted on:fieldDuplicated />
+    <AbstractField {field} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved />
   {/each}
 </div>

--- a/src/lib/editor/form/RootField.svelte
+++ b/src/lib/editor/form/RootField.svelte
@@ -17,6 +17,6 @@
     <h1 class="text-sm capitalize text-grey-4 font-bold p-2">{title}</h1>
   {/if}
   {#each children || emptyChildren as field (field.id)}
-    <AbstractField {field} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved />
+    <AbstractField {field} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved on:fieldValueUpdated />
   {/each}
 </div>

--- a/src/lib/editor/form/RootField.svelte
+++ b/src/lib/editor/form/RootField.svelte
@@ -17,6 +17,6 @@
     <h1 class="text-sm capitalize text-grey-4 font-bold p-2">{title}</h1>
   {/if}
   {#each children || emptyChildren as field (field.id)}
-    <AbstractField {field} on:fieldAdded on:fieldDeleted />
+    <AbstractField {field} on:fieldAdded on:fieldDeleted on:fieldDuplicated />
   {/each}
 </div>

--- a/src/lib/editor/form/RootField.svelte
+++ b/src/lib/editor/form/RootField.svelte
@@ -17,6 +17,6 @@
     <h1 class="text-sm capitalize text-grey-4 font-bold p-2">{title}</h1>
   {/if}
   {#each children || emptyChildren as field (field.id)}
-    <AbstractField {field} />
+    <AbstractField {field} on:fieldAdded />
   {/each}
 </div>

--- a/src/lib/editor/form/RootField.svelte
+++ b/src/lib/editor/form/RootField.svelte
@@ -17,6 +17,14 @@
     <h1 class="text-sm capitalize text-grey-4 font-bold p-2">{title}</h1>
   {/if}
   {#each children || emptyChildren as field (field.id)}
-    <AbstractField {field} on:fieldAdded on:fieldDeleted on:fieldDuplicated on:fieldMoved on:fieldValueUpdated />
+    <AbstractField
+      {field}
+      on:fieldAdded
+      on:fieldDeleted
+      on:fieldDuplicated
+      on:fieldMoved
+      on:fieldValueUpdated
+      on:fieldKeyUpdated
+    />
   {/each}
 </div>

--- a/src/lib/editor/form/RootField.svelte
+++ b/src/lib/editor/form/RootField.svelte
@@ -17,6 +17,6 @@
     <h1 class="text-sm capitalize text-grey-4 font-bold p-2">{title}</h1>
   {/if}
   {#each children || emptyChildren as field (field.id)}
-    <AbstractField {field} on:fieldAdded />
+    <AbstractField {field} on:fieldAdded on:fieldDeleted />
   {/each}
 </div>

--- a/src/lib/editor/form/StringField.svelte
+++ b/src/lib/editor/form/StringField.svelte
@@ -15,5 +15,5 @@
   }
 </script>
 
-<LeafField {...props} parseValue={handleParseValue} />
+<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated />
 <slot />

--- a/src/lib/editor/form/StringField.svelte
+++ b/src/lib/editor/form/StringField.svelte
@@ -15,5 +15,5 @@
   }
 </script>
 
-<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated />
+<LeafField {...props} parseValue={handleParseValue} on:fieldValueUpdated on:fieldKeyUpdated />
 <slot />

--- a/src/lib/editor/form/context/formEditor.ts
+++ b/src/lib/editor/form/context/formEditor.ts
@@ -13,7 +13,6 @@ export const recreatingUiModel = writable(false);
 export type FormEditorContextType = {
   uiModel: Readable<{ value: UIModelRootField | undefined; updatedAt: number }>;
   changeFieldKey(field: UIModelField, value: SchemaValue): void;
-  changeFieldValue(field: UIModelField, value: SchemaValue): void;
   sortField(field: UIModelField, position: number): string | undefined;
   refreshUI(): void;
   updateEditor(): void;
@@ -78,13 +77,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     updateEditor(field.root);
   }
 
-  function changeFieldValue(field: UIModelField, value: SchemaValue) {
-    const result = field.setValue(value);
-    if (!result) return;
-
-    updateEditor(field.root);
-  }
-
   function sortField(field: UIModelField, position: number, update = false): string | undefined {
     const result = field.sortField(position);
     if (!result) return;
@@ -108,7 +100,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
   const initialState: FormEditorContextType = {
     uiModel,
     changeFieldKey,
-    changeFieldValue,
     sortField,
     refreshUI,
     updateEditor,

--- a/src/lib/editor/form/context/formEditor.ts
+++ b/src/lib/editor/form/context/formEditor.ts
@@ -14,7 +14,7 @@ export type FormEditorContextType = {
   uiModel: Readable<{ value: UIModelRootField | undefined; updatedAt: number }>;
   changeFieldKey(field: UIModelField, value: SchemaValue): void;
   changeFieldValue(field: UIModelField, value: SchemaValue): void;
-  duplicateField(field: UIModelField): void;
+  // duplicateField(field: UIModelField): void;
   moveField(field: UIModelField, direction: "up" | "down"): void;
   addField(parentField: UIModelField, option: SchemaOption): void;
   sortField(field: UIModelField, position: number): string | undefined;
@@ -88,19 +88,19 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     updateEditor(field.root);
   }
 
-  function duplicateField(field: UIModelField) {
-    const newField = field.duplicate();
-    if (!newField) return;
+  // function duplicateField(field: UIModelField) {
+  //   const newField = field.duplicate();
+  //   if (!newField) return;
 
-    updateEditor();
-    refreshUI();
+  //   updateEditor();
+  //   refreshUI();
 
-    const focusField = newField.getFirstFocusableChild();
+  //   const focusField = newField.getFirstFocusableChild();
 
-    if (!focusField) return;
-  
-    focusField.tryFocus()
-  }
+  //   if (!focusField) return;
+
+  //   focusField.tryFocus()
+  // }
 
   function moveField(field: UIModelField, direction: "up" | "down") {
     const swapPositions = (array: UIModelField[], a: number, b: number) => {
@@ -135,7 +135,7 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
 
     if (!focusField) return;
 
-    focusField.tryFocus()
+    focusField.tryFocus();
   }
 
   function sortField(field: UIModelField, position: number, update = false): string | undefined {
@@ -162,7 +162,7 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     uiModel,
     changeFieldKey,
     changeFieldValue,
-    duplicateField,
+    // duplicateField,
     moveField,
     addField,
     sortField,

--- a/src/lib/editor/form/context/formEditor.ts
+++ b/src/lib/editor/form/context/formEditor.ts
@@ -14,7 +14,6 @@ export type FormEditorContextType = {
   uiModel: Readable<{ value: UIModelRootField | undefined; updatedAt: number }>;
   changeFieldKey(field: UIModelField, value: SchemaValue): void;
   changeFieldValue(field: UIModelField, value: SchemaValue): void;
-  deleteField(field: UIModelField): void;
   duplicateField(field: UIModelField): void;
   moveField(field: UIModelField, direction: "up" | "down"): void;
   addField(parentField: UIModelField, option: SchemaOption): void;
@@ -87,14 +86,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     if (!result) return;
 
     updateEditor(field.root);
-  }
-
-  function deleteField(field: UIModelField) {
-    const result = field.delete();
-    if (!result) return;
-
-    updateEditor();
-    refreshUI();
   }
 
   function duplicateField(field: UIModelField) {
@@ -171,7 +162,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     uiModel,
     changeFieldKey,
     changeFieldValue,
-    deleteField,
     duplicateField,
     moveField,
     addField,

--- a/src/lib/editor/form/context/formEditor.ts
+++ b/src/lib/editor/form/context/formEditor.ts
@@ -1,6 +1,6 @@
 import { getContext, onDestroy, setContext } from "svelte";
 import { editor, editorJSON } from "$lib/editor/stores.js";
-import { type UIModelRootField, UIModelField, type SchemaOption, getUIModel } from "$lib/editor/form/utils/model.js";
+import { type UIModelRootField, UIModelField, getUIModel } from "$lib/editor/form/utils/model.js";
 import { getDebouncedFunction } from "$lib/editor/form/utils/debounce.js";
 import type { SchemaValue } from "../utils/schema.js";
 import { writableDerived } from "$lib/store/writableDerived.js";
@@ -14,9 +14,6 @@ export type FormEditorContextType = {
   uiModel: Readable<{ value: UIModelRootField | undefined; updatedAt: number }>;
   changeFieldKey(field: UIModelField, value: SchemaValue): void;
   changeFieldValue(field: UIModelField, value: SchemaValue): void;
-  // duplicateField(field: UIModelField): void;
-  moveField(field: UIModelField, direction: "up" | "down"): void;
-  addField(parentField: UIModelField, option: SchemaOption): void;
   sortField(field: UIModelField, position: number): string | undefined;
   refreshUI(): void;
   updateEditor(): void;
@@ -88,56 +85,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     updateEditor(field.root);
   }
 
-  // function duplicateField(field: UIModelField) {
-  //   const newField = field.duplicate();
-  //   if (!newField) return;
-
-  //   updateEditor();
-  //   refreshUI();
-
-  //   const focusField = newField.getFirstFocusableChild();
-
-  //   if (!focusField) return;
-
-  //   focusField.tryFocus()
-  // }
-
-  function moveField(field: UIModelField, direction: "up" | "down") {
-    const swapPositions = (array: UIModelField[], a: number, b: number) => {
-      array[a].key = String(b);
-      array[b].key = String(a);
-      [array[a], array[b]] = [array[b], array[a]];
-    };
-
-    const children = field?.parent?.children || [];
-
-    const factor = direction === "down" ? 1 : -1;
-
-    const currentKey = Number(field?.key);
-    const destinationKey = currentKey + factor;
-
-    if (destinationKey < 0 || destinationKey >= children.length) return;
-
-    swapPositions(children, currentKey, destinationKey);
-
-    updateEditor();
-    refreshUI();
-  }
-
-  function addField(parentField: UIModelField, option: SchemaOption) {
-    const newField = parentField.addChildField(option, undefined);
-    if (!newField) return;
-
-    updateEditor();
-    refreshUI();
-
-    const focusField = newField.getFirstFocusableChild();
-
-    if (!focusField) return;
-
-    focusField.tryFocus();
-  }
-
   function sortField(field: UIModelField, position: number, update = false): string | undefined {
     const result = field.sortField(position);
     if (!result) return;
@@ -162,9 +109,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     uiModel,
     changeFieldKey,
     changeFieldValue,
-    // duplicateField,
-    moveField,
-    addField,
     sortField,
     refreshUI,
     updateEditor,

--- a/src/lib/editor/form/context/formEditor.ts
+++ b/src/lib/editor/form/context/formEditor.ts
@@ -1,8 +1,7 @@
-import { getContext, onDestroy, setContext } from "svelte";
+import { getContext, setContext } from "svelte";
 import { editor, editorJSON } from "$lib/editor/stores.js";
-import { type UIModelRootField, UIModelField, getUIModel } from "$lib/editor/form/utils/model.js";
+import { type UIModelRootField, getUIModel } from "$lib/editor/form/utils/model.js";
 import { getDebouncedFunction } from "$lib/editor/form/utils/debounce.js";
-import type { SchemaValue } from "../utils/schema.js";
 import { writableDerived } from "$lib/store/writableDerived.js";
 import { get, writable, type Readable, type Writable } from "svelte/store";
 
@@ -12,10 +11,6 @@ export const recreatingUiModel = writable(false);
 
 export type FormEditorContextType = {
   uiModel: Readable<{ value: UIModelRootField | undefined; updatedAt: number }>;
-  changeFieldKey(field: UIModelField, value: SchemaValue): void;
-  sortField(field: UIModelField, position: number): string | undefined;
-  refreshUI(): void;
-  updateEditor(): void;
   updateSchema(value: string): void;
 };
 
@@ -38,11 +33,6 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const debouncedRecreateUIModel = getDebouncedFunction(200, recreateUIModel as any);
 
-  let uiModelValue: UIModelRootField | undefined;
-  const unsubscribeUiModelValue = uiModel.subscribe(({ value }) => {
-    uiModelValue = value;
-  });
-
   async function recreateUIModel(
     schema: string,
     set: (value: { value: UIModelRootField | undefined; updatedAt: number }) => void,
@@ -52,42 +42,12 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
     const model = (await getUIModel(schema, value)) as UIModelRootField | undefined;
 
     if (model && model?.value !== value) {
-      updateEditor(model);
+      const value = model.root.toJSON();
+      editor.set({ value, updatedAt: Date.now() });
     }
 
     set({ value: model, updatedAt: Date.now() });
     recreatingUiModel.set(false);
-  }
-
-  function updateEditor(model: UIModelField | undefined = uiModelValue) {
-    if (!model) return;
-
-    const value = model.root.toJSON();
-    editor.set({ value, updatedAt: Date.now() });
-  }
-
-  function refreshUI() {
-    uiModel.update(({ value }) => ({ value, updatedAt: Date.now() }));
-  }
-
-  function changeFieldKey(field: UIModelField, key: string) {
-    const result = field.setKey(key);
-    if (!result) return;
-
-    updateEditor(field.root);
-  }
-
-  function sortField(field: UIModelField, position: number, update = false): string | undefined {
-    const result = field.sortField(position);
-    if (!result) return;
-
-    if (update) {
-      updateEditor();
-    } else {
-      refreshUI();
-    }
-
-    return result;
   }
 
   async function updateSchema(value: string) {
@@ -99,16 +59,8 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
 
   const initialState: FormEditorContextType = {
     uiModel,
-    changeFieldKey,
-    sortField,
-    refreshUI,
-    updateEditor,
     updateSchema,
   };
-
-  onDestroy(() => {
-    unsubscribeUiModelValue();
-  });
 
   return setContext<FormEditorContextType>(FormEditorContextId, initialState);
 }

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -540,10 +540,6 @@ export class UIModelField<V extends SchemaValue | unknown = unknown> {
         value = 0;
         break;
       }
-      case "boolean": {
-        value = true;
-        break;
-      }
     }
 
     // @note: Override default values of specific form control types
@@ -552,11 +548,6 @@ export class UIModelField<V extends SchemaValue | unknown = unknown> {
     switch (controlType) {
       case "date": {
         value = new Date().toISOString().split("T")[0];
-        break;
-      }
-      case "select": {
-        const [firstOption] = this.getControlMeta(option.schema) as { key: string; value: string }[];
-        value = firstOption.value;
         break;
       }
       case "dictionary": {

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -7,8 +7,8 @@ export async function generateCorrectOptionsModel(schema: string) {
   const options = schemaObj.$defs.CorrectionOptions;
   const parsedSchema = await parseSchema(schemaObj.$id, options);
 
-  const CORRECTION_OPTIONS_SCHEMA_URL = 'https://gobl.org/draft-0/bill/correction-options?tax_regime=';
-  parsedSchema.title = `Correction Options [${parsedSchema.$id?.replace(CORRECTION_OPTIONS_SCHEMA_URL, '')}]`;
+  const CORRECTION_OPTIONS_SCHEMA_URL = "https://gobl.org/draft-0/bill/correction-options?tax_regime=";
+  parsedSchema.title = `Correction Options [${parsedSchema.$id?.replace(CORRECTION_OPTIONS_SCHEMA_URL, "")}]`;
 
   return getUIModel(parsedSchema as Schema, "");
 }

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -363,6 +363,25 @@ export class UIModelField<V extends SchemaValue | unknown = unknown> {
     return this.parent.type === "array" ? sortedChilds[position].id : this.id;
   }
 
+  move(direction: "up" | "down") {
+    const swapPositions = (array: UIModelField[], a: number, b: number) => {
+      array[a].key = String(b);
+      array[b].key = String(a);
+      [array[a], array[b]] = [array[b], array[a]];
+    };
+
+    const children = this.parent?.children || [];
+
+    const factor = direction === "down" ? 1 : -1;
+
+    const currentKey = Number(this.key);
+    const destinationKey = currentKey + factor;
+
+    if (destinationKey < 0 || destinationKey >= children.length) return;
+
+    swapPositions(children, currentKey, destinationKey);
+  }
+
   getNextFocusableField(reverse = false): UIModelField | undefined {
     if (this.is.root) {
       return this.getFirstFocusableChild(reverse);

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -7,6 +7,9 @@ export async function generateCorrectOptionsModel(schema: string) {
   const options = schemaObj.$defs.CorrectionOptions;
   const parsedSchema = await parseSchema(schemaObj.$id, options);
 
+  const CORRECTION_OPTIONS_SCHEMA_URL = 'https://gobl.org/draft-0/bill/correction-options?tax_regime=';
+  parsedSchema.title = `Correction Options [${parsedSchema.$id?.replace(CORRECTION_OPTIONS_SCHEMA_URL, '')}]`;
+
   return getUIModel(parsedSchema as Schema, "");
 }
 

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -3,11 +3,11 @@ import { getRootSchema, parseSchema, type Schema, type SchemaValue } from "./sch
 import { sleep } from "./sleep.js";
 
 export async function generateCorrectOptionsModel(schema: string) {
-  const schemaObj = JSON.parse(schema)
+  const schemaObj = JSON.parse(schema);
   const options = schemaObj.$defs.CorrectionOptions;
-  const parsedSchema = await parseSchema(schemaObj.$id, options)
+  const parsedSchema = await parseSchema(schemaObj.$id, options);
 
-  return getUIModel(parsedSchema as Schema, '');
+  return getUIModel(parsedSchema as Schema, "");
 }
 
 export async function getUIModel<V extends SchemaValue>(

--- a/src/lib/editor/form/utils/schema.ts
+++ b/src/lib/editor/form/utils/schema.ts
@@ -15,10 +15,10 @@ const EMPTY_SCHEMA: Schema = {
 
 export async function fetchJsonSchema(url: string) {
   const GOBL_URL = "https://gobl.org/draft-0/";
+  // We only support loading json from the worker without ?query=modifiers
+  const GOBL_URL_REGEX = /^https:\/\/gobl\.org\/draft-0\/[^?]*$/;
 
-  const matchUrl = new RegExp(GOBL_URL, "g");
-
-  const isGoblSchema = matchUrl.test(url);
+  const isGoblSchema = GOBL_URL_REGEX.test(url);
 
   if (isGoblSchema) {
     return await GOBL.schema(url.replace(GOBL_URL, ""));
@@ -66,7 +66,7 @@ async function fetchSchema(id: string): Promise<Schema> {
   return schema;
 }
 
-async function parseSchema(id: string, schema: Schema): Promise<Schema> {
+export async function parseSchema(id: string, schema: Schema): Promise<Schema> {
   const pSchema = { ...schema, $id: id };
   delete pSchema.$ref;
   delete pSchema.$defs;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,6 @@
-export function formatErrors(error: string) {
+import { toast } from "@zerodevx/svelte-toast";
+
+export function formatErrors(error: string): string[] {
   // If error does not start with doc: we assume it is a calculation error
   if (!error.startsWith("doc:")) {
     return [error];
@@ -33,4 +35,28 @@ export function formatErrors(error: string) {
   readParsedObj(parsed.doc);
 
   return errors;
+}
+
+export function showErrorToast(error: string) {
+  toast.push(error, {
+    duration: 10000,
+    reversed: true,
+    intro: { y: 192 },
+    theme: {
+      "--toastColor": "rgb(75 85 99)",
+      "--toastBackground": "rgb(255 228 230)",
+      "--toastBarBackground": "rgb(225 29 72)",
+    },
+  });
+}
+
+export function displayAllErrors(error: string) {
+  try {
+    const errors = formatErrors(error);
+    errors.forEach((e) => {
+      showErrorToast(e);
+    });
+  } catch (error) {
+    showErrorToast(error as string);
+  }
 }

--- a/src/lib/types/editor.ts
+++ b/src/lib/types/editor.ts
@@ -1,1 +1,1 @@
-export type State = "init" | "empty" | "loaded" | "modified" | "invalid" | "errored" | "built" | "signed";
+export type State = "init" | "empty" | "loaded" | "modified" | "invalid" | "errored" | "built" | "signed" | "corrected";

--- a/src/lib/ui/icons/CorrectIcon.svelte
+++ b/src/lib/ui/icons/CorrectIcon.svelte
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke-width="1.5"
+  stroke="currentColor"
+  class="w-5 h-5"
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M8.25 9.75h4.875a2.625 2.625 0 010 5.25H12M8.25 9.75L10.5 7.5M8.25 9.75L10.5 12m9-7.243V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0c1.1.128 1.907 1.077 1.907 2.185z"
+  />
+</svg>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
   import type { State } from "$lib/types/editor";
   import SelectSchemas from "$lib/SelectSchemas.svelte";
   import ExportDoc from "$lib/actions/ExportDoc.svelte";
+  import CorrectIcon from "$lib/ui/icons/CorrectIcon.svelte";
 
   interface GOBLDocument {
     $schema: string;
@@ -75,6 +76,15 @@
             clip-rule="evenodd"
           />
         </svg>
+      </button>
+      <button
+        title="Correct document."
+        on:click={() => {
+          builder.correct();
+        }}
+        class={iconButtonClasses(!["built", "loaded", "signed"].includes(state))}
+      >
+        <CorrectIcon />
       </button>
       <button
         title="Sign document."


### PR DESCRIPTION
- Refactored the visual editor to be an agnostic component
- uiModel is passed from outside
- Methods for interacting with the UI are now self-contained in the model and not coupled to a store
- Added a new modal that uses a different version of the visual editor to load the correction options
- This first iteration uses a props down / event up approach for child-parent communication. Keeping the components agnostic of the logic. We can iterate this more, especially when Svelte 5 and runes get released.

![](http://g.recordit.co/QLpkH76N0C.gif)