### PR TITLE
Show num/amount and num/percent schemas right aligned

### DIFF
--- a/src/lib/editor/form/AbstractField.svelte
+++ b/src/lib/editor/form/AbstractField.svelte
@@ -20,6 +20,7 @@
     object: ObjectField as typeof SvelteComponent,
     array: ArrayField as typeof SvelteComponent,
     string: StringField as typeof SvelteComponent,
+    number: StringField as typeof SvelteComponent,
     integer: IntegerField as typeof SvelteComponent,
     boolean: BooleanField as typeof SvelteComponent,
   };

--- a/src/lib/editor/form/EditableTextField.svelte
+++ b/src/lib/editor/form/EditableTextField.svelte
@@ -36,6 +36,7 @@
   class:border-slate-100={field.is.calculated}
   class:border-rose-500={showError}
   class:focus:border-rose-500={showError}
+  class:text-right={field.schema.type === "number"}
 />
 
 <style lang="postcss">

--- a/src/lib/editor/form/EditableTextField.svelte
+++ b/src/lib/editor/form/EditableTextField.svelte
@@ -10,6 +10,7 @@
 
   $: iid = id || field.id;
   $: val = value || field.value;
+  $: fieldType = Array.isArray(field.schema.type) ? field.schema.type[0] : field.schema.type || "";
 
   const dispatch = createEventDispatcher();
 
@@ -36,7 +37,7 @@
   class:border-slate-100={field.is.calculated}
   class:border-rose-500={showError}
   class:focus:border-rose-500={showError}
-  class:text-right={field.schema.type === "number"}
+  class:text-right={["number", "integer"].includes(fieldType)}
 />
 
 <style lang="postcss">

--- a/src/lib/editor/form/utils/schema.ts
+++ b/src/lib/editor/form/utils/schema.ts
@@ -80,6 +80,8 @@ export async function parseSchema(id: string, schema: Schema): Promise<Schema> {
     return {
       ...refSchema,
       ...pSchema,
+      // type: "number" is used to display the content right aligned
+      type: relId.includes("num/amount") || relId.includes("num/percent") ? "number" : refSchema.type,
     };
   }
 


### PR DESCRIPTION
Considerations:
- I had to update the type of the schema from `string` to `number`. Not very happy with this workaround but it works. Maybe we should use the JsonSchema property `format` for this? 
- It looks great when several amounts are one after another (like sums and totals) but not so great when strings and numbers are mixed on the same section.