### PR TITLE
Creates a unique identifier per visual form instance

### DIFF
--- a/src/lib/GOBLBuilder.svelte
+++ b/src/lib/GOBLBuilder.svelte
@@ -239,7 +239,7 @@
 
     // Attemp autobuild after editor refreshes
     setTimeout(() => {
-      if (!envelopeValue?.doc) return;
+      if (forceReadOnly || !envelopeValue?.doc || $envelopeIsSigned) return;
 
       build();
     }, 100);

--- a/src/lib/editor/code/EditorCode.svelte
+++ b/src/lib/editor/code/EditorCode.svelte
@@ -216,7 +216,7 @@
       }
     });
 
-    // Obly dispose the editor if there is only one active model
+    // Only dispose the editor if there is only one active model
     if (models.length === 1) {
       monacoEditor?.dispose();
       readOnlyEditHandler?.dispose();

--- a/src/lib/editor/code/EditorCode.svelte
+++ b/src/lib/editor/code/EditorCode.svelte
@@ -30,7 +30,8 @@
 
   let unsubscribeEditor: Unsubscriber;
 
-  const goblDocURL = "gobl://doc.json";
+  const EditorUniqueId = Math.random().toString(36).slice(2, 7);
+  const goblDocURL = `gobl://doc.json?${EditorUniqueId}`;
 
   // Sort by `monaco.MarkerSeverity` enum value descending, most severe shown first.
   $: sortedProblems = $problems.sort((a, b) => b.severity - a.severity);
@@ -205,10 +206,22 @@
     if (unsubscribeEditor != null) {
       unsubscribeEditor();
     }
-    // model.dispose();
-    monaco?.editor.getModels().forEach((m) => m.dispose());
-    monacoEditor?.dispose();
-    readOnlyEditHandler?.dispose();
+
+    const models = monaco?.editor.getModels();
+
+    monaco?.editor.getModels().forEach((m) => {
+      // Only dispose the model that matches with the unique URI
+      if (m.uri.query === EditorUniqueId) {
+        m.dispose();
+      }
+    });
+
+    // Obly dispose the editor if there is only one active model
+    if (models.length === 1) {
+      monacoEditor?.dispose();
+      readOnlyEditHandler?.dispose();
+    }
+
     document.removeEventListener("undoButtonClick", handleUndoButtonClick, true);
     document.removeEventListener("redoButtonClick", handleRedoButtonClick, true);
     console.log("destroying editor");

--- a/src/lib/editor/form/EditorForm.svelte
+++ b/src/lib/editor/form/EditorForm.svelte
@@ -43,7 +43,7 @@
     if (!fields) return;
 
     const rootKey = fields.key;
-    const root = { slug: rootKey, label: `${rootKey.charAt(0).toUpperCase()}${rootKey.slice(1)}`, active: true };
+    const root = { slug: fields.id, label: `${rootKey.charAt(0).toUpperCase()}${rootKey.slice(1)}`, active: true };
     const items =
       fields.children
         ?.filter((f) => ["object", "array"].includes(f.type))
@@ -144,7 +144,7 @@
   {#if $recreatingUiModel}
     <div class="text-center mt-6 w-full flex items-center justify-center"><LoadingIcon /></div>
   {:else}
-    {#if documentHeaders.length && documentHeaders[0].slug !== "root"}
+    {#if documentHeaders.length && !documentHeaders[0].slug.includes("root")}
       <div class="pt-7 absolute top-1 left-1 bg-white w-36 @[1055px]:w-56 hidden @[800px]:block z-10">
         <ul>
           {#each documentHeaders as header}

--- a/src/lib/editor/form/context/formEditor.ts
+++ b/src/lib/editor/form/context/formEditor.ts
@@ -19,6 +19,8 @@ export function getFormEditorContext(): FormEditorContextType {
 }
 
 export function createFormEditorContext(jsonSchemaURL: Readable<string | null>): FormEditorContextType {
+  const formUniqueId = Math.random().toString(36).slice(2, 7);
+
   const uiModel: Writable<{
     value: UIModelRootField | undefined;
     updatedAt: number;
@@ -39,7 +41,7 @@ export function createFormEditorContext(jsonSchemaURL: Readable<string | null>):
   ) {
     recreatingUiModel.set(true);
     const value = get(editorJSON).value;
-    const model = (await getUIModel(schema, value)) as UIModelRootField | undefined;
+    const model = (await getUIModel(schema, value, formUniqueId)) as UIModelRootField | undefined;
 
     if (model && model?.value !== value) {
       const value = model.root.toJSON();

--- a/src/lib/editor/form/modals/EditorFormModalHeaders.svelte
+++ b/src/lib/editor/form/modals/EditorFormModalHeaders.svelte
@@ -15,7 +15,7 @@
   }
 
   async function generateHeadersModel(schema: SchemaValue) {
-    headerModel = await getUIModel("https://gobl.org/draft-0/head/header", schema);
+    headerModel = await getUIModel("https://gobl.org/draft-0/head/header", schema, "headers");
   }
 
   function handleConfirm() {


### PR DESCRIPTION
**Problem:**
- When more than one visual forms are rendered at the same time (i.e Console read-only view page that opens an edit modal) same field IDs were created (#invoice-supplier-uuid)
- Using the left sidebar for section scrolling would cause scrolling in both main and modal editor
- Adding a field to a section (i.e Supplier) would add a child to both forms since `model.ts` is using plain javascript and DOM element insertion based on the `id`
- Monaco editor does not allow to create two different models using the same URI

**Solution:**
- Each instance of EditorForm is now creating a random `formUniqueId` property on context creation
- This identifier is passed down the field creation
- Resulting HTML IDs are now something like `#usdjf-invoice-supplier-uuid` which will not collide with other form instances
- Added a unique query param to the URI string when creating the Monaco editor instance