### PR TITLE
remove empty options from oneOf schemas to avoid collisions with empty placehoders

### DIFF
--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -517,7 +517,11 @@ export class UIModelField<V extends SchemaValue | unknown = unknown> {
         options = (schema.anyOf || []).map((v: any) => ({ label: v.title || v.description, value: v.const }));
       }
 
-      return [{ label: "", value: "" }, ...options.sort((a, b) => a.label.localeCompare(b.label))];
+      // We add a default empty option and remove any empty value that may cause duplications
+      return [
+        { label: "", value: "" },
+        ...options.filter((o) => o.value !== "").sort((a, b) => a.label.localeCompare(b.label)),
+      ];
     }
 
     if (controlType === "dictionary" && !!schema.patternProperties?.[".*"]) {


### PR DESCRIPTION
Some schemas such as https://gobl.org/draft-0/pay/terms have properties with empty values that may collide with default placeholders on visual builder.

This PR filters those values from the options array keeping only the default placeholder.