### PR TITLE
Migrate error handling to new gobl-worker faults array

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: 'npm'
       - run: npm install
       - run: npm run check

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-22.20.0
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@invopop/gobl-worker": "^0.309.0",
+        "@invopop/gobl-worker": "^0.400.0-rc1",
         "@invopop/popui": "0.1.19",
         "@invopop/ui-icons": "^0.0.67",
         "@monaco-editor/loader": "^1.4.0",
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@invopop/gobl-worker": {
-      "version": "0.309.0",
-      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.309.0.tgz",
-      "integrity": "sha512-9z4TUW6KEjT1NEe6LRbJrOq9f/H0/aWd8IxT7znwWxA+QyMOdx1wpBG1nzZOsz7uEfwrbAfsQIJSDIaqosG09g==",
+      "version": "0.400.0-rc1",
+      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.400.0-rc1.tgz",
+      "integrity": "sha512-GvbjMnTTSxeQDoHW5B7jSV1dt9WuHquXReiNXKmVwpyNikuTEfrTKKdiInr1wd7RACMolJvEYd2fEkhiYRz0yg==",
       "license": "Apache-2.0"
     },
     "node_modules/@invopop/popui": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "vscode-uri": "^3.0.7"
   },
   "dependencies": {
-    "@invopop/gobl-worker": "^0.309.0",
+    "@invopop/gobl-worker": "^0.400.0-rc1",
     "@invopop/popui": "0.1.19",
     "@invopop/ui-icons": "^0.0.67",
     "@monaco-editor/loader": "^1.4.0",

--- a/src/lib/editor/code/EditorCode.svelte
+++ b/src/lib/editor/code/EditorCode.svelte
@@ -11,7 +11,7 @@
   import SuccessIcon from '$lib/ui/icons/SuccessIcon.svelte'
   import LightbulbIcon from '$lib/ui/icons/LightbulbIcon.svelte'
   import { getBuilderContext } from '$lib/store/builder.js'
-  import { getAgentSystem, getGOBLErrorMessage } from '$lib/helpers'
+  import { getAgentSystem, getGOBLErrorMessages } from '$lib/helpers'
   import type { EditorCodeProps } from '$lib/types/editor'
 
   let monaco: typeof Monaco | undefined = $state()
@@ -168,16 +168,15 @@
         return
       }
 
-      const errorString = getGOBLErrorMessage(goblErr.message)
+      const m = monaco
+      const errorsArr = getGOBLErrorMessages(goblErr.message)
 
-      const errorsArr = errorString.split(' / ')
-
-      monaco.editor.setModelMarkers(
+      m.editor.setModelMarkers(
         model,
         'gobl',
         errorsArr.map((message: string) => ({
           message,
-          severity: monaco?.MarkerSeverity.Error,
+          severity: m.MarkerSeverity.Error,
           startLineNumber: 1,
           startColumn: 1,
           endLineNumber: 1,

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -37,54 +37,45 @@ export function formatErrors(error: string): string[] {
   return errors
 }
 
-export function getErrorString(errorObj: Record<string, object | string>) {
-  const errorString = parseErrorString(errorObj)
+type GOBLFault = { code?: string; paths?: string[]; message?: string }
+type ParsedGOBLError = { key?: string; faults?: GOBLFault[]; message?: string }
 
-  return errorString.substring(3)
+function formatFaultPath(path: string) {
+  if (!path || path === '$') return '$'
+  return path.startsWith('$.') ? path.slice(2) : path
 }
 
-export function parseErrorString(errorObj: Record<string, object | string>, currentPath = '') {
-  let errorString = ''
+export function getGOBLErrorMessages(message: string): string[] {
+  let parsed: ParsedGOBLError
+  try {
+    parsed = JSON.parse(message)
+  } catch {
+    return [message]
+  }
 
-  for (const [key, value] of Object.entries(errorObj)) {
-    const newPath = currentPath ? `${currentPath} > ${key}` : key
-
-    if (typeof value === 'object' && value !== null) {
-      errorString += parseErrorString(value as Record<string, object | string>, newPath)
-    } else {
-      errorString += ` / ${newPath}: ${value}`
+  if (Array.isArray(parsed.faults) && parsed.faults.length > 0) {
+    const messages: string[] = []
+    for (const fault of parsed.faults) {
+      const text = fault.message || ''
+      const paths = fault.paths && fault.paths.length > 0 ? fault.paths : ['$']
+      for (const path of paths) {
+        messages.push(`${formatFaultPath(path)}: ${text}`)
+      }
     }
+    if (messages.length > 0) return messages
   }
 
-  return errorString
-}
-
-export function getGOBLErrorMessage(message: string) {
-  const parsedError = JSON.parse(message)
-
-  let m = ''
-
-  if (parsedError.key === 'validation') {
-    m = getErrorString(parsedError.fields?.doc || parsedError.fields?.head || {})
-  }
-
-  if (parsedError.key === 'calculation') {
-    m = getErrorString(parsedError.fields || {})
-  }
-
-  return m || parsedError.message || parsedError.key || 'Unknown error'
+  return [parsed.message || parsed.key || 'Unknown error']
 }
 
 export async function displayAllErrors(
   error: string,
   toastFunction?: (notification: NotificationProps) => void
 ) {
-  const errorMessage = getGOBLErrorMessage(error)
-  const errorsArr = errorMessage.split(' / ')
-
-  for (let i = 0; i < errorsArr.length; i++) {
-    if (!toastFunction) return
-    toastFunction({ message: errorsArr[i], type: 'error' })
+  if (!toastFunction) return
+  const errors = getGOBLErrorMessages(error)
+  for (const message of errors) {
+    toastFunction({ message, type: 'error' })
   }
 }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -58,8 +58,9 @@ export function getGOBLErrorMessages(message: string): string[] {
     for (const fault of parsed.faults) {
       const text = fault.message || ''
       const paths = fault.paths && fault.paths.length > 0 ? fault.paths : ['$']
+      const prefix = fault.code ? `[${fault.code}] ` : ''
       for (const path of paths) {
-        messages.push(`${formatFaultPath(path)}: ${text}`)
+        messages.push(`${prefix}${formatFaultPath(path)}: ${text}`)
       }
     }
     if (messages.length > 0) return messages


### PR DESCRIPTION
## Summary
- Upgrade `@invopop/gobl-worker` from `0.309.0` to `0.400.0-rc1`, which replaces the nested `fields` map in error payloads with a flat `faults` array (`{ code, paths[], message }`).
- Rewrite `getGOBLErrorMessage` (now `getGOBLErrorMessages`) in `src/lib/helpers.ts` to parse the new shape and return `string[]`, emitting one entry per fault path formatted as `path: message`. Falls back to the top-level `message`/`key` for non-validation errors, and returns the raw input if JSON parsing fails.
- Update `EditorCode.svelte` and `displayAllErrors` to consume the array directly — no more `.split(' / ')` round-trip.
- Restore `engine-strict=true` in `.npmrc`. A prior commit had overwritten it with `22.20.0` (a node version that already lives in `.nvmrc`), which npm printed as an "Unknown project config" warning on every invocation.

## Test plan
- [ ] `npm run check` passes.
- [ ] Load an invoice, clear a required field (e.g. `type`, `issue_date`), trigger build; Monaco Problems panel shows one marker per fault path with `path: message` text.
- [ ] Same scenario via `EnvelopeEditor` surfaces one toast per fault path.
- [ ] Malformed JSON in the code view still surfaces the non-validation top-level message.
- [ ] `npm install` no longer prints the "Unknown project config 22.20.0" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)