### PR TITLE
Fix correction options schema resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@invopop/gobl-worker": "^0.400.0-rc1",
+        "@invopop/gobl-worker": "^0.400.1",
         "@invopop/popui": "0.1.19",
         "@invopop/ui-icons": "^0.0.67",
         "@monaco-editor/loader": "^1.4.0",
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@invopop/gobl-worker": {
-      "version": "0.400.0-rc1",
-      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.400.0-rc1.tgz",
-      "integrity": "sha512-GvbjMnTTSxeQDoHW5B7jSV1dt9WuHquXReiNXKmVwpyNikuTEfrTKKdiInr1wd7RACMolJvEYd2fEkhiYRz0yg==",
+      "version": "0.400.1",
+      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.400.1.tgz",
+      "integrity": "sha512-l/O6GnfNK9eDDBFCbNfpxkxnZslz7KA0JEIf/Dpiglut+YGdpAAwdFbaT5QCWkcXNRg0nOmfVEDerR2pzilr8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@invopop/popui": {
@@ -1061,9 +1061,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,9 +1073,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1093,9 +1087,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1108,9 +1099,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1125,9 +1113,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1140,9 +1125,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1157,9 +1139,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1172,9 +1151,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1189,9 +1165,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1204,9 +1177,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1221,9 +1191,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1237,9 +1204,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1252,9 +1216,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1642,9 +1603,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1660,9 +1618,6 @@
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1680,9 +1635,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,9 +1650,6 @@
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3932,9 +3881,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3954,9 +3900,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3978,9 +3921,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4000,9 +3940,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "vscode-uri": "^3.0.7"
   },
   "dependencies": {
-    "@invopop/gobl-worker": "^0.400.0-rc1",
+    "@invopop/gobl-worker": "^0.400.1",
     "@invopop/popui": "0.1.19",
     "@invopop/ui-icons": "^0.0.67",
     "@monaco-editor/loader": "^1.4.0",

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -4,7 +4,15 @@ import { sleep } from './sleep.js'
 
 export async function generateCorrectOptionsModel(schema: string) {
   const schemaObj = JSON.parse(schema)
-  const options = schemaObj.$defs.CorrectionOptions
+  // Follow the top-level $ref to locate the correction options definition
+  // inside $defs, rather than relying on a fixed key name.
+  const defsKey = schemaObj.$ref?.replace(/^#\/\$defs\//, '')
+  const options = defsKey ? schemaObj.$defs?.[defsKey] : undefined
+
+  if (!options) {
+    throw new Error(`Correction options schema not found at ${schemaObj.$ref}`)
+  }
+
   const parsedSchema = await parseSchema(schemaObj.$id, options, schemaObj)
 
   const CORRECTION_OPTIONS_SCHEMA_URL =


### PR DESCRIPTION
Correcting a document was failing with an error because the code was looking for the correction options under a hardcoded key that no longer matches what GOBL returns.

Now we follow the schema's own reference to locate the definition, so it keeps working regardless of the key name.
