### PR TITLE
Replace GOBL WASM worker with gobl.dev HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,24 @@ npm run preview
 This uses `vite` to serve a previously built `build` folder on
 http://localhost:4173.
 
-### GOBL WASM binary
+### GOBL API
 
-GOBL Builder makes use of [gobl cli](https://github.com/invopop/gobl?tab=readme-ov-file#cli) for
-validating, calculating and building GOBL documents. This is done using the [@invopop/gobl-worker](https://www.npmjs.com/package/@invopop/gobl-worker) package that prepares a Worker and uses the WASM binary distributed on `cdn.gobl.org`.
+GOBL Builder uses the [GOBL API](https://docs.gobl.org/api/introduction) for
+validating, calculating, building, signing, and correcting GOBL documents, as
+well as fetching JSON schemas. By default, requests are sent to the public
+service at `https://gobl.dev/v0`.
 
-To upgrade the version of the GOBL worker currently in use, simply update the [package.json](./package.json) file to reflect the new version.
+When embedding the builder, the endpoint can be overridden with the
+`apiBaseUrl` prop on both `EnvelopeEditor` and `ObjectEditor`, for example to
+point at a same-origin path that proxies the GOBL API and adds authentication:
+
+```html
+<EnvelopeEditor
+  data=""
+  jsonSchemaURL="https://gobl.org/draft-0/bill/invoice"
+  apiBaseUrl="/api/gobl"
+/>
+```
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@invopop/gobl-worker": "^0.403.0",
         "@invopop/popui": "0.1.19",
         "@invopop/ui-icons": "^0.0.67",
         "@monaco-editor/loader": "^1.4.0",
@@ -17,7 +16,6 @@
         "@tailwindcss/container-queries": "^0.1.1",
         "@tailwindcss/vite": "^4.1.13",
         "@zerodevx/svelte-toast": "^0.9.5",
-        "base-64": "^1.0.0",
         "clsx": "^2.0.0",
         "country-list": "^2.3.0",
         "date-picker-svelte": "^2.11.0",
@@ -33,7 +31,6 @@
         "svelte-intersection-observer-action": "^0.0.4",
         "svelte-select": "^5.7.0",
         "svelte-sonner": "^1.0.5",
-        "utf8": "^3.0.0",
         "vscode-json-languageservice": "5.3.5"
       },
       "devDependencies": {
@@ -43,13 +40,10 @@
         "@sveltejs/package": "^2.3.7",
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
         "@tailwindcss/forms": "^0.5.4",
-        "@types/base-64": "^1.0.0",
         "@types/country-list": "^2.1.1",
         "@types/file-saver": "^2.0.5",
-        "@types/golang-wasm-exec": "^1.15.0",
         "@types/node": "^20.5.7",
         "@types/object-hash": "^3.0.3",
-        "@types/utf8": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
         "@typescript-eslint/parser": "^6.2.1",
         "autoprefixer": "^10.4.14",
@@ -686,12 +680,6 @@
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
-    },
-    "node_modules/@invopop/gobl-worker": {
-      "version": "0.403.0",
-      "resolved": "https://registry.npmjs.org/@invopop/gobl-worker/-/gobl-worker-0.403.0.tgz",
-      "integrity": "sha512-5gC2LSX99jAAW13Ma+WAAnpvRNTUp/FXqUnGPvqW0KfDKvnghxR2PGAqxZPVjUMZkDE5jeJOB8pX6+WHhYQ+lA==",
-      "license": "Apache-2.0"
     },
     "node_modules/@invopop/popui": {
       "version": "0.1.19",
@@ -1735,13 +1723,6 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
-    "node_modules/@types/base-64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/base-64/-/base-64-1.0.2.tgz",
-      "integrity": "sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1778,13 +1759,6 @@
       "dependencies": {
         "flatpickr": "*"
       }
-    },
-    "node_modules/@types/golang-wasm-exec": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@types/golang-wasm-exec/-/golang-wasm-exec-1.15.2.tgz",
-      "integrity": "sha512-NA77toY4yOiiV5foDVT/rfxmtoox7ASHqGs4Eek8xTMcKWwAhZLOD3SYfLQKq4P2jtOLQQkeISq3zSuQ1Y+apg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1828,13 +1802,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/utf8": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/utf8/-/utf8-3.0.3.tgz",
-      "integrity": "sha512-+lqLGxWZsEe4Z6OrzBI7Ym4SMUTaMS5yOrHZ0/IL0bpIye1Qbs4PpobJL2mLDbftUXlPFZR7fu6d1yM+bHLX1w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2206,12 +2173,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/base-64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -5776,12 +5737,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -57,13 +57,10 @@
     "@sveltejs/package": "^2.3.7",
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
     "@tailwindcss/forms": "^0.5.4",
-    "@types/base-64": "^1.0.0",
     "@types/country-list": "^2.1.1",
     "@types/file-saver": "^2.0.5",
-    "@types/golang-wasm-exec": "^1.15.0",
     "@types/node": "^20.5.7",
     "@types/object-hash": "^3.0.3",
-    "@types/utf8": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.2.1",
     "autoprefixer": "^10.4.14",
@@ -89,7 +86,6 @@
     "vscode-uri": "^3.0.7"
   },
   "dependencies": {
-    "@invopop/gobl-worker": "^0.403.0",
     "@invopop/popui": "0.1.19",
     "@invopop/ui-icons": "^0.0.67",
     "@monaco-editor/loader": "^1.4.0",
@@ -97,7 +93,6 @@
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/vite": "^4.1.13",
     "@zerodevx/svelte-toast": "^0.9.5",
-    "base-64": "^1.0.0",
     "clsx": "^2.0.0",
     "country-list": "^2.3.0",
     "date-picker-svelte": "^2.11.0",
@@ -113,7 +108,6 @@
     "svelte-intersection-observer-action": "^0.0.4",
     "svelte-select": "^5.7.0",
     "svelte-sonner": "^1.0.5",
-    "utf8": "^3.0.0",
     "vscode-json-languageservice": "5.3.5"
   },
   "overrides": {

--- a/src/lib/EnvelopeEditor.svelte
+++ b/src/lib/EnvelopeEditor.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import * as GOBL from '@invopop/gobl-worker'
+  import * as GOBL from '$lib/gobl/client'
   import hash from 'object-hash'
   import { envelopeDocumentJSON } from '$lib/helpers/envelope'
   import EditorCode from './editor/code/EditorCode.svelte'
   import EditorForm from './editor/form/EditorForm.svelte'
-  import { isEnvelope } from '@invopop/gobl-worker'
+  import { isEnvelope, setApiBaseUrl, DEFAULT_API_BASE_URL } from '$lib/gobl/client'
   import { problemSeverityMap } from './editor/EditorProblem.js'
   import * as actions from './editor/actions'
   import type { BuildOptions, DocumentHeader, State } from './types/editor'
@@ -19,6 +19,7 @@
 
   let {
     jsonSchemaURL = '',
+    apiBaseUrl = DEFAULT_API_BASE_URL,
     data = $bindable(''),
     state: initialState = $bindable('init'),
     problems = $bindable([]),
@@ -38,6 +39,14 @@
     onReplicate,
     onNotification
   }: EnvelopeEditorProps = $props()
+
+  // Configure the GOBL API endpoint before any operation runs. The initial
+  // value is applied eagerly during init; the effect keeps it in sync.
+  // svelte-ignore state_referenced_locally
+  setApiBaseUrl(apiBaseUrl)
+  $effect(() => {
+    setApiBaseUrl(apiBaseUrl)
+  })
 
   let editorForm: EditorForm | null = $state(null)
   let initialEditorData = ''
@@ -182,7 +191,7 @@
       return
     }
 
-    return await generateCorrectOptionsModel(result?.schema || '')
+    return await generateCorrectOptionsModel(result.schema)
   }
 
   export const correctWithOptions = async (options: string) => {

--- a/src/lib/ObjectEditor.svelte
+++ b/src/lib/ObjectEditor.svelte
@@ -2,16 +2,26 @@
   import DynamicForm from '$lib/editor/form/DynamicForm.svelte'
   import { getUIModel } from '$lib/editor/form/utils/model'
   import type { SchemaValue } from '$lib/editor/form/utils/schema'
+  import { setApiBaseUrl, DEFAULT_API_BASE_URL } from '$lib/gobl/client'
   import { createBuilderContext } from './store/builder'
   import type { ObjectEditorProps } from './types/editor'
 
   let {
     jsonSchemaURL = '',
+    apiBaseUrl = DEFAULT_API_BASE_URL,
     data = undefined,
     id = `editor-${Math.random().toString(36).slice(2, 7)}`,
     readOnly = false,
     model = $bindable(undefined)
   }: ObjectEditorProps = $props()
+
+  // Configure the GOBL API endpoint before any schema is fetched. The initial
+  // value is applied eagerly during init; the effect keeps it in sync.
+  // svelte-ignore state_referenced_locally
+  setApiBaseUrl(apiBaseUrl)
+  $effect(() => {
+    setApiBaseUrl(apiBaseUrl)
+  })
 
   createBuilderContext()
 

--- a/src/lib/editor/actions.ts
+++ b/src/lib/editor/actions.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store'
-import * as GOBL from '@invopop/gobl-worker'
-import { encodeUTF8ToBase64 } from '$lib/encodeUTF8ToBase64.js'
+import * as GOBL from '$lib/gobl/client'
 import { envelopeGOBLSchema } from '$lib/helpers/envelope'
+import type { Envelope } from '$lib/types/envelope'
 import type {
   BuildActionResponse,
   BuilderContext,
@@ -9,7 +9,7 @@ import type {
   ValidateActionResponse
 } from '$lib/types/editor'
 
-// Send a request to the GOBL worker to run the "build" operation using the current
+// Send a request to the GOBL API to run the "build" operation using the current
 // editor window contents and update with the results.
 export async function build(
   ctx: BuilderContext,
@@ -22,13 +22,7 @@ export async function build(
   try {
     const sendData = getGOBLPayload(ctx, options)
 
-    const payload: GOBL.BuildPayload = {
-      data: encodeUTF8ToBase64(sendData),
-      draft: true,
-      envelop: true
-    }
-    const rawResult = await GOBL.build({ payload })
-    const result = JSON.parse(rawResult)
+    const result = await GOBL.build<Envelope>(sendData, { envelop: true })
 
     ctx.envelope.set(result)
     ctx.goblError.set(null)
@@ -44,7 +38,7 @@ export async function build(
   }
 }
 
-// Send a request to the GOBL worker to run the "sign" operation using the current
+// Send a request to the GOBL API to run the "sign" operation using the current
 // editor window contents and update with the results.
 export async function sign(ctx: BuilderContext): Promise<BuildActionResponse> {
   const { keypair } = ctx
@@ -57,12 +51,7 @@ export async function sign(ctx: BuilderContext): Promise<BuildActionResponse> {
   try {
     const sendData = getGOBLPayload(ctx)
 
-    const payload: GOBL.SignPayload = {
-      data: encodeUTF8ToBase64(sendData),
-      privatekey: keypairValue.private
-    }
-    const rawResult = await GOBL.sign({ payload })
-    const result = JSON.parse(rawResult)
+    const result = await GOBL.sign<Envelope>(sendData, keypairValue.private)
 
     ctx.envelope.set(result)
     ctx.goblError.set(null)
@@ -78,7 +67,7 @@ export async function sign(ctx: BuilderContext): Promise<BuildActionResponse> {
   }
 }
 
-// Send a request to the GOBL worker to run the "validate" operation using the current
+// Send a request to the GOBL API to run the "validate" operation using the current
 // editor window contents and update with the results.
 export async function validate(ctx: BuilderContext): Promise<ValidateActionResponse> {
   if (!get(ctx.validEditor) || !get(ctx.envelopeIsSigned)) {
@@ -88,10 +77,7 @@ export async function validate(ctx: BuilderContext): Promise<ValidateActionRespo
   try {
     const sendData = getGOBLPayload(ctx)
 
-    const payload: GOBL.ValidatePayload = {
-      data: encodeUTF8ToBase64(sendData)
-    }
-    await GOBL.validate({ payload })
+    await GOBL.validate(sendData)
 
     ctx.goblError.set(null)
 
@@ -107,7 +93,7 @@ export async function validate(ctx: BuilderContext): Promise<ValidateActionRespo
   }
 }
 
-// Send a request to the GOBL worker to run the "replicate" operation using the current editor window contents.
+// Send a request to the GOBL API to run the "replicate" operation using the current editor window contents.
 export async function replicate(ctx: BuilderContext): Promise<BuildActionResponse> {
   if (!get(ctx.validEditor)) {
     return {}
@@ -116,12 +102,7 @@ export async function replicate(ctx: BuilderContext): Promise<BuildActionRespons
   try {
     const sendData = getGOBLPayload(ctx)
 
-    const payload: GOBL.ValidatePayload = {
-      data: encodeUTF8ToBase64(sendData)
-    }
-
-    const rawResult = await GOBL.replicate({ payload })
-    const result = JSON.parse(rawResult)
+    const result = await GOBL.replicate<Envelope>(sendData)
 
     return { result }
   } catch (e) {
@@ -134,7 +115,7 @@ export async function replicate(ctx: BuilderContext): Promise<BuildActionRespons
   }
 }
 
-// Send a request to the GOBL worker to get the adecuate correction fields using
+// Send a request to the GOBL API to get the adecuate correction fields using
 // editor window contents to read the tax regime.
 export async function getCorrectionOptionsSchema(ctx: BuilderContext) {
   if (!get(ctx.validEditor)) {
@@ -144,12 +125,7 @@ export async function getCorrectionOptionsSchema(ctx: BuilderContext) {
   try {
     const sendData = getGOBLPayload(ctx)
 
-    const payload: GOBL.CorrectPayload = {
-      data: encodeUTF8ToBase64(sendData),
-      schema: true
-    }
-
-    const schema = await GOBL.correct({ payload })
+    const schema = await GOBL.correctionOptionsSchema(sendData)
 
     ctx.goblError.set(null)
 
@@ -159,7 +135,7 @@ export async function getCorrectionOptionsSchema(ctx: BuilderContext) {
   }
 }
 
-// Send a request to the GOBL worker to run the "correct" operation using the current
+// Send a request to the GOBL API to run the "correct" operation using the current
 // editor window contents and update with the results.
 export async function correct(
   options: string,
@@ -173,13 +149,7 @@ export async function correct(
   try {
     const sendData = getGOBLPayload(ctx)
 
-    const payload: GOBL.CorrectPayload = {
-      data: encodeUTF8ToBase64(sendData),
-      options: encodeUTF8ToBase64(options)
-    }
-
-    const rawResult = await GOBL.correct({ payload })
-    const result = JSON.parse(rawResult)
+    const result = await GOBL.correct<Envelope>(sendData, JSON.parse(options))
 
     if (autocorrect) {
       ctx.envelope.set(result)
@@ -199,8 +169,7 @@ export async function correct(
 }
 
 export async function getSchemas() {
-  const schemas = await GOBL.schemas()
-  return JSON.parse(schemas).list
+  return await GOBL.schemas()
 }
 
 function getGOBLPayload(ctx: BuilderContext, options: BuildOptions = {}) {
@@ -214,9 +183,9 @@ function getGOBLPayload(ctx: BuilderContext, options: BuildOptions = {}) {
     delete envelopeValue.sigs
   }
   if (doc.$schema == envelopeGOBLSchema) {
-    return editorValue.value || '' // send as-is
+    return doc // send as-is
   }
   envelopeValue.doc = doc
 
-  return JSON.stringify(envelopeValue)
+  return envelopeValue
 }

--- a/src/lib/editor/form/utils/faultPaths.ts
+++ b/src/lib/editor/form/utils/faultPaths.ts
@@ -1,4 +1,4 @@
-import type { GOBLError } from '@invopop/gobl-worker'
+import type { GOBLError } from '$lib/gobl/client'
 import { parseGOBLError } from '$lib/helpers'
 import { parseJSONPath } from '$lib/editor/code/faultLocator'
 import type { UIModelField } from './model'

--- a/src/lib/editor/form/utils/model.ts
+++ b/src/lib/editor/form/utils/model.ts
@@ -2,8 +2,12 @@ import { tick } from 'svelte'
 import { getRootSchema, parseSchema, type Schema, type SchemaValue } from './schema.js'
 import { sleep } from './sleep.js'
 
-export async function generateCorrectOptionsModel(schema: string) {
-  const schemaObj = JSON.parse(schema)
+export async function generateCorrectOptionsModel(schema: Record<string, unknown>) {
+  const schemaObj = schema as {
+    $ref?: string
+    $id?: string
+    $defs?: Record<string, Schema>
+  } & Record<string, unknown>
   // Follow the top-level $ref to locate the correction options definition
   // inside $defs, rather than relying on a fixed key name.
   const defsKey = schemaObj.$ref?.replace(/^#\/\$defs\//, '')
@@ -13,7 +17,7 @@ export async function generateCorrectOptionsModel(schema: string) {
     throw new Error(`Correction options schema not found at ${schemaObj.$ref}`)
   }
 
-  const parsedSchema = await parseSchema(schemaObj.$id, options, schemaObj)
+  const parsedSchema = await parseSchema(schemaObj.$id ?? '', options, schemaObj)
 
   const CORRECTION_OPTIONS_SCHEMA_URL =
     'https://gobl.org/draft-0/bill/correction-options?tax_regime='

--- a/src/lib/editor/form/utils/schema.ts
+++ b/src/lib/editor/form/utils/schema.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema7 } from 'json-schema'
 import { path } from './path.js'
-import * as GOBL from '@invopop/gobl-worker'
+import * as GOBL from '$lib/gobl/client'
 
 export type Schema = JSONSchema7
 
@@ -13,15 +13,15 @@ const EMPTY_SCHEMA: Schema = {
   properties: {}
 }
 
-export async function fetchJsonSchema(url: string) {
+export async function fetchJsonSchema(url: string): Promise<Schema> {
   const GOBL_URL = 'https://gobl.org/draft-0/'
-  // We only support loading json from the worker without ?query=modifiers
+  // We only support loading json from the API without ?query=modifiers
   const GOBL_URL_REGEX = /^https:\/\/gobl\.org\/draft-0\/[^?]*$/
 
   const isGoblSchema = GOBL_URL_REGEX.test(url)
 
   if (isGoblSchema) {
-    return await GOBL.schema(url.replace(GOBL_URL, ''))
+    return (await GOBL.schema(url.replace(GOBL_URL, ''))) as Schema
   }
 
   const response = await fetch(url)
@@ -41,9 +41,7 @@ async function fetchExternalSchema(id: string): Promise<Schema> {
   if (schema) return schema
 
   try {
-    const result = await fetchJsonSchema(id)
-
-    schema = JSON.parse(result)
+    schema = await fetchJsonSchema(id)
 
     SchemaRegistry[id] = schema
 

--- a/src/lib/encodeUTF8ToBase64.ts
+++ b/src/lib/encodeUTF8ToBase64.ts
@@ -1,6 +1,0 @@
-import utf8 from 'utf8'
-import base64 from 'base-64'
-
-export function encodeUTF8ToBase64(value: string): string {
-  return base64.encode(utf8.encode(value))
-}

--- a/src/lib/gobl/client.ts
+++ b/src/lib/gobl/client.ts
@@ -1,0 +1,128 @@
+import { envelopeGOBLSchema } from '$lib/helpers/envelope'
+
+// Default public GOBL API endpoint. Embedders can override this via the
+// `apiBaseUrl` prop on the editor components, for example to point at a
+// same-origin proxy endpoint that adds authentication.
+export const DEFAULT_API_BASE_URL = 'https://gobl.dev/v0'
+
+let apiBaseUrl = DEFAULT_API_BASE_URL
+
+// Set the base URL used for all GOBL API requests. A trailing slash is
+// stripped so paths can be appended consistently.
+export function setApiBaseUrl(url: string) {
+  if (!url) return
+  apiBaseUrl = url.replace(/\/+$/, '')
+}
+
+export function getApiBaseUrl(): string {
+  return apiBaseUrl
+}
+
+// GOBLError mirrors the error structure previously provided by the WASM
+// worker: `message` contains the raw JSON error body returned by the API
+// (parsed downstream by `parseGOBLError` in `$lib/helpers`), and `code` is
+// the HTTP status code.
+export type GOBLError = {
+  message: string
+  code: number
+}
+
+export type Keypair = {
+  private: JsonWebKey
+  public: Omit<JsonWebKey, 'd'>
+}
+
+// Normalize an unknown thrown value into a GOBLError.
+export function parseGOBLError(err: unknown): GOBLError {
+  if (err && typeof err === 'object' && 'message' in err) {
+    const e = err as { message: unknown; code?: unknown }
+    return {
+      message: String(e.message),
+      code: typeof e.code === 'number' ? e.code : 0
+    }
+  }
+  return { message: String(err), code: 0 }
+}
+
+export function isEnvelope(data: Record<string, unknown> | null): boolean {
+  return data?.$schema === envelopeGOBLSchema
+}
+
+// Documents are accepted as any plain object (bare GOBL document or full
+// envelope) and returned as parsed JSON.
+type DocumentInput = object
+type DocumentResult = Record<string, unknown>
+
+async function request<T>(
+  path: string,
+  opts: { method?: string; body?: unknown } = {}
+): Promise<T> {
+  const hasBody = opts.body !== undefined
+  const res = await fetch(`${apiBaseUrl}${path}`, {
+    method: opts.method ?? 'POST',
+    headers: hasBody ? { 'Content-Type': 'application/json' } : undefined,
+    body: hasBody ? JSON.stringify(opts.body) : undefined
+  })
+
+  if (!res.ok) {
+    // Keep the raw response body as the error message: it contains the
+    // GOBL error JSON ({key, message, faults}) consumed downstream.
+    const goblErr: GOBLError = { message: await res.text(), code: res.status }
+    throw goblErr
+  }
+
+  return (await res.json()) as T
+}
+
+// Parse, calculate and validate a document, optionally wrapping it in an
+// envelope. `data` may be a bare document or a full envelope.
+export function build<T = DocumentResult>(
+  data: DocumentInput,
+  opts: { envelop?: boolean } = {}
+): Promise<T> {
+  return request('/build', { body: { data, ...opts } })
+}
+
+// Build the document, wrap it in an envelope and sign it with the given
+// private key.
+export function sign<T = DocumentResult>(data: DocumentInput, privatekey: JsonWebKey): Promise<T> {
+  return request('/sign', { body: { data, privatekey } })
+}
+
+// Validate a document or envelope without modifying it. Throws a GOBLError
+// when validation fails.
+export async function validate(data: DocumentInput): Promise<void> {
+  await request('/validate', { body: { data } })
+}
+
+// Generate a credit note, debit note or corrective document.
+export function correct<T = DocumentResult>(data: DocumentInput, options?: object): Promise<T> {
+  return request('/correct', { body: { data, options } })
+}
+
+// Fetch the JSON schema describing the correction options available for the
+// given document. Returns null when the document cannot be corrected.
+export function correctionOptionsSchema(data: DocumentInput): Promise<DocumentResult | null> {
+  return request('/correct', { body: { data, schema: true } })
+}
+
+// Create a copy of the document with a fresh UUID and no signatures.
+export function replicate<T = DocumentResult>(data: DocumentInput): Promise<T> {
+  return request('/replicate', { body: { data } })
+}
+
+// Generate a new ES256 keypair for signing documents.
+export function keygen(): Promise<Keypair> {
+  return request('/keygen')
+}
+
+// List the IDs of all available JSON schemas.
+export async function schemas(): Promise<string[]> {
+  const res = await request<{ schemas: string[] }>('/schemas', { method: 'GET' })
+  return res.schemas
+}
+
+// Fetch a single JSON schema by path, e.g. "bill/invoice".
+export function schema(path: string): Promise<DocumentResult> {
+  return request(`/schemas/${path}`, { method: 'GET' })
+}

--- a/src/lib/monaco-editor/json.worker.ts
+++ b/src/lib/monaco-editor/json.worker.ts
@@ -28,7 +28,7 @@ self.onmessage = () => {
 let defaultSchemaRequestService: ((url: string) => Promise<string>) | undefined
 if (typeof fetch !== 'undefined') {
   defaultSchemaRequestService = async function (url: string) {
-    return await fetchJsonSchema(url)
+    return JSON.stringify(await fetchJsonSchema(url))
   }
 }
 

--- a/src/lib/store/builder.ts
+++ b/src/lib/store/builder.ts
@@ -1,5 +1,5 @@
 import type { BuilderContext, NotificationProps } from '$lib/types/editor'
-import type { GOBLError } from '@invopop/gobl-worker'
+import type { GOBLError } from '$lib/gobl/client'
 import { getContext, setContext } from 'svelte'
 import { derived, get, writable, type Writable } from 'svelte/store'
 import type * as monaco from 'monaco-editor'

--- a/src/lib/types/editor.ts
+++ b/src/lib/types/editor.ts
@@ -1,5 +1,5 @@
 import type * as monaco from 'monaco-editor'
-import type { GOBLError, Keypair } from '@invopop/gobl-worker'
+import type { GOBLError, Keypair } from '$lib/gobl/client'
 import type { Readable, Writable } from 'svelte/store'
 import type { UIModelField, UIModelRootField } from '$lib/editor/form/utils/model'
 import type { FaultIndex } from '$lib/editor/form/utils/faultPaths'
@@ -81,7 +81,7 @@ export type BuilderContext = {
 }
 
 export interface BuildActionResponse {
-  result?: string
+  result?: Envelope
   error?: GOBLError
 }
 
@@ -204,6 +204,11 @@ export interface NotificationProps {
 export interface EnvelopeEditorProps {
   // Used for JSON Schema validation within Monaco Editor. When set, this should  be the JSON Schema URL of a GOBL document, e.g. an invoice. Not an envelope.
   jsonSchemaURL?: string
+  // Base URL of the GOBL API used for build, sign, validate, correct,
+  // replicate, keygen and schema operations. Defaults to the public service at
+  // `https://gobl.dev/v0`. Embedders may point this at a same-origin path
+  // (e.g. `/api/gobl`) that proxies the GOBL API and adds authentication.
+  apiBaseUrl?: string
   // Data is used for setting editor contents. Note: there is "one way" binding;
   // e.g. you can set data but changes are not bound to the parent. Use the
   // `change` event, to receive changes to the editor contents and GOBL
@@ -319,6 +324,9 @@ export interface ModalProps {
 
 export interface ObjectEditorProps {
   jsonSchemaURL?: string
+  // Base URL of the GOBL API used to fetch JSON schemas. See
+  // `EnvelopeEditorProps.apiBaseUrl`.
+  apiBaseUrl?: string
   data?: unknown
   id?: string
   readOnly?: boolean


### PR DESCRIPTION
## Summary

Replaces the `@invopop/gobl-worker` WASM dependency with a lightweight HTTP client that talks to the [GOBL API](https://docs.gobl.org/api/introduction), defaulting to the public service at `https://gobl.dev/v0`.

- **New `src/lib/gobl/client.ts`** — fetch-based client for `build`, `sign`, `validate`, `correct` (incl. correction-options schema), `replicate`, `keygen`, `schemas` and `schema`, plus the re-homed `GOBLError`/`Keypair` types and `isEnvelope`/`parseGOBLError` helpers.
- **New `apiBaseUrl` prop** on `EnvelopeEditor` and `ObjectEditor` so embedders can point the builder at a different endpoint — e.g. the console can pass a same-origin path like `/api/{company}/gobl` that proxies the GOBL API and adds authentication (cookies flow automatically).
- **Error contract preserved**: on non-2xx responses the client throws `{ message: <raw response body>, code: <status> }`, keeping the existing fault parsing intact (Monaco markers, form fault highlighting, error toasts).
- Payloads are now plain JSON — the base64 encoding layer (`encodeUTF8ToBase64.ts`, `base-64`, `utf8` deps) is removed along with `@invopop/gobl-worker` and `@types/golang-wasm-exec`.
- `BuildActionResponse.result` is now typed `Envelope` (runtime value was always a parsed object; consumers doing `JSON.stringify(response.result)` are unaffected).
- README updated to describe the HTTP API and `apiBaseUrl`.

Note: Monaco's code-view schema hints still fetch schemas directly from `gobl.org/draft-0/*` via its own schema request mechanism (pre-existing behaviour, unaffected by `apiBaseUrl`).

## Verification

- `npm run check` (0 errors/warnings), `npm run lint`, `svelte-package` all pass.
- Drove the demo app headless with Playwright:
  - Load ES invoice → Build → `POST /v0/build` 200, envelope updated with calculated totals.
  - Invalid invoice → 422 with `{key, faults}` rendered in the console bar with fault codes.
  - Sign → `POST /v0/sign` 200, signed toast, editor read-only; Validate → `{ok:true}`.
  - Form view → schemas loaded via `GET /v0/schemas/...`, form renders.
  - `apiBaseUrl` override probe: pointed the demo at a local proxy — **all** requests (keygen, schemas, build) routed through it, zero direct gobl.dev calls.
  - Zero requests to `cdn.gobl.org` in all runs.

## Follow-up (separate repos)

The console backend will need to expose the GOBL API operations under the path passed as `apiBaseUrl`, and console-ui can then set the prop on `EnvelopeEditor`/`ObjectEditor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)