### PR TITLE
Stop the Monaco editor fetching schemas from gobl.org directly

### DIFF
--- a/src/lib/editor/code/EditorCode.svelte
+++ b/src/lib/editor/code/EditorCode.svelte
@@ -62,12 +62,15 @@
     let enableSchemaRequest = false
     let schemas: { uri: string; fileMatch?: string[]; schema?: unknown }[] = []
     if (uri) {
+      // loadSchemaSet returns fragment-free URIs, so match against the
+      // same base when attaching the document to its root schema.
+      const baseURI = uri.split('#')[0]
       try {
-        schemas = (await loadSchemaSet(uri)).map((entry) =>
-          entry.uri === uri ? { ...entry, fileMatch: [goblDocURL] } : entry
+        schemas = (await loadSchemaSet(baseURI)).map((entry) =>
+          entry.uri === baseURI ? { ...entry, fileMatch: [goblDocURL] } : entry
         )
       } catch {
-        schemas = [{ fileMatch: [goblDocURL], uri }]
+        schemas = [{ fileMatch: [goblDocURL], uri: baseURI }]
         enableSchemaRequest = true
       }
     }

--- a/src/lib/editor/code/EditorCode.svelte
+++ b/src/lib/editor/code/EditorCode.svelte
@@ -12,6 +12,7 @@
   import LightbulbIcon from '$lib/ui/icons/LightbulbIcon.svelte'
   import { getBuilderContext } from '$lib/store/builder.js'
   import { getAgentSystem, formatFaultMessage, parseGOBLError } from '$lib/helpers'
+  import { loadSchemaSet } from '../form/utils/schema.js'
   import { parseSource, resolveFaultRange } from './faultLocator'
   import type { EditorCodeProps } from '$lib/types/editor'
 
@@ -47,22 +48,38 @@
     }
   }
 
-  function setSchemaURI(uri: string) {
+  let schemaRequestId = 0
+
+  async function setSchemaURI(uri: string) {
     if (!monaco) {
       return
     }
+    const requestId = ++schemaRequestId
+
+    // Preload the schema and everything it references through the GOBL API
+    // client so monaco validates without fetching schemas from gobl.org
+    // itself. Fall back to monaco's own schema requests if that fails.
+    let enableSchemaRequest = false
+    let schemas: { uri: string; fileMatch?: string[]; schema?: unknown }[] = []
+    if (uri) {
+      try {
+        schemas = (await loadSchemaSet(uri)).map((entry) =>
+          entry.uri === uri ? { ...entry, fileMatch: [goblDocURL] } : entry
+        )
+      } catch {
+        schemas = [{ fileMatch: [goblDocURL], uri }]
+        enableSchemaRequest = true
+      }
+    }
+    if (!monaco || requestId !== schemaRequestId) {
+      return
+    }
+
     monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
-      enableSchemaRequest: true,
+      enableSchemaRequest,
       schemaValidation: 'warning',
-      schemas: uri
-        ? [
-            {
-              fileMatch: [goblDocURL],
-              uri
-            }
-          ]
-        : []
+      schemas
     })
     if (monacoEditor) {
       const value = monacoEditor.getValue()

--- a/src/lib/editor/form/utils/schema.ts
+++ b/src/lib/editor/form/utils/schema.ts
@@ -14,14 +14,13 @@ const EMPTY_SCHEMA: Schema = {
 }
 
 export async function fetchJsonSchema(url: string): Promise<Schema> {
-  const GOBL_URL = 'https://gobl.org/draft-0/'
-  // We only support loading json from the API without ?query=modifiers
-  const GOBL_URL_REGEX = /^https:\/\/gobl\.org\/draft-0\/[^?]*$/
+  // Query modifiers (e.g. ?tax_regime=) are ignored by the schema servers,
+  // so they are stripped before loading the schema through the API.
+  const GOBL_URL_REGEX = /^https:\/\/gobl\.org\/draft-0\/([^?#]+)/
 
-  const isGoblSchema = GOBL_URL_REGEX.test(url)
-
-  if (isGoblSchema) {
-    return (await GOBL.schema(url.replace(GOBL_URL, ''))) as Schema
+  const match = url.match(GOBL_URL_REGEX)
+  if (match) {
+    return (await GOBL.schema(match[1])) as Schema
   }
 
   const response = await fetch(url)
@@ -63,6 +62,55 @@ async function fetchSchema(id: string): Promise<Schema> {
 
   SchemaRegistry[id] = schema
   return schema
+}
+
+// loadSchemaSet fetches the schema at the given URL together with every
+// GOBL schema it references, directly or transitively, reusing the shared
+// SchemaRegistry cache. Callers like the Monaco code editor can then
+// validate documents without requesting any schemas from gobl.org.
+export async function loadSchemaSet(url: string): Promise<Array<{ uri: string; schema: Schema }>> {
+  const found = new Map<string, Schema>()
+  const queue = [url.split('#')[0]]
+
+  while (queue.length > 0) {
+    const id = queue.shift() as string
+    if (found.has(id)) continue
+
+    const schema = await fetchExternalSchema(id)
+    found.set(id, schema)
+
+    for (const ref of collectGOBLRefs(schema)) {
+      const base = ref.split('#')[0]
+      if (base && !found.has(base)) {
+        queue.push(base)
+      }
+    }
+  }
+
+  return [...found.entries()].map(([uri, schema]) => ({ uri, schema }))
+}
+
+function collectGOBLRefs(node: unknown, refs = new Set<string>()): Set<string> {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectGOBLRefs(item, refs)
+    }
+    return refs
+  }
+  if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        key === '$ref' &&
+        typeof value === 'string' &&
+        value.startsWith('https://gobl.org/draft-0/')
+      ) {
+        refs.add(value)
+      } else {
+        collectGOBLRefs(value, refs)
+      }
+    }
+  }
+  return refs
 }
 
 export async function parseSchema(

--- a/src/lib/editor/form/utils/schema.ts
+++ b/src/lib/editor/form/utils/schema.ts
@@ -68,9 +68,16 @@ async function fetchSchema(id: string): Promise<Schema> {
 // GOBL schema it references, directly or transitively, reusing the shared
 // SchemaRegistry cache. Callers like the Monaco code editor can then
 // validate documents without requesting any schemas from gobl.org.
+// Throws when the root schema cannot be loaded; missing referenced schemas
+// degrade to an empty placeholder instead.
 export async function loadSchemaSet(url: string): Promise<Array<{ uri: string; schema: Schema }>> {
+  const rootId = url.split('#')[0]
+  if (!SchemaRegistry[rootId]) {
+    SchemaRegistry[rootId] = await fetchJsonSchema(rootId)
+  }
+
   const found = new Map<string, Schema>()
-  const queue = [url.split('#')[0]]
+  const queue = [rootId]
 
   while (queue.length > 0) {
     const id = queue.shift() as string


### PR DESCRIPTION
## Summary

When embedders point the builder at their own API via `apiBaseUrl` (e.g. the Invopop console proxying to silo), schema requests were still being duplicated against gobl.org. Two leaks:

1. **Monaco code editor**: the JSON language service was configured with `enableSchemaRequest: true` and the raw `https://gobl.org/draft-0/...` URI, so monaco's worker fetched the document schema *and every `$ref` in its transitive closure* directly from gobl.org — a full parallel set of requests alongside the form editor's API-client fetches.
2. **Query-modifier URLs**: `fetchJsonSchema` only routed gobl.org URLs *without* a query string through the API client; URLs like `bill/correction-options?tax_regime=ES` (used as `$id` on correction-options schemas) fell back to a direct `fetch()` against gobl.org.

## Changes

- New `loadSchemaSet(url)` in `form/utils/schema.ts`: fetches a schema plus its transitive GOBL references via the shared `SchemaRegistry` cache (so the form and code editors share one set of requests) and returns them as `{uri, schema}` pairs.
- `setSchemaURI` in `EditorCode.svelte` preloads that set and passes the schemas to monaco **inline** with `enableSchemaRequest: false`; if preloading fails it falls back to the previous behavior. A request token guards against out-of-order async updates.
- `fetchJsonSchema` now strips query/fragment from gobl.org URLs and routes them through the API client. Verified the schema servers ignore query modifiers (`curl` of both variants is byte-identical), so this is behavior-preserving while eliminating the external fetch.

## Testing

- `npm run check` — 0 errors, 0 warnings.
- `npm run lint` and `npm run build:package` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)