### PR TITLE
Keep the schema registry pristine from form-parser mutations

### DIFF
--- a/src/lib/editor/form/utils/schema.ts
+++ b/src/lib/editor/form/utils/schema.ts
@@ -94,7 +94,9 @@ export async function loadSchemaSet(url: string): Promise<Array<{ uri: string; s
     }
   }
 
-  return [...found.entries()].map(([uri, schema]) => ({ uri, schema }))
+  // Deep-clone the returned schemas so callers hold a stable snapshot that
+  // can never share mutable objects with the registry or the form parser.
+  return [...found.entries()].map(([uri, schema]) => ({ uri, schema: structuredClone(schema) }))
 }
 
 function collectGOBLRefs(node: unknown, refs = new Set<string>()): Set<string> {
@@ -208,7 +210,11 @@ export async function parseSchema(
 }
 
 async function getSchema(id: string, value: SchemaValue) {
-  let schema = await fetchSchema(id)
+  // parseSchema rewrites parts of the schema for form display (e.g. it
+  // forces num/amount refs to type "number" for alignment) and mutates
+  // nested objects in place, so parse a deep clone to keep the cached
+  // registry copy pristine for other consumers like the Monaco editor.
+  let schema = structuredClone(await fetchSchema(id))
   schema = await parseSchema(id, schema, value)
 
   return schema


### PR DESCRIPTION
## Summary

Fixes the regression introduced by #240 where, in environments running 0.186.0, **every `num.Amount` field is flagged with `Incorrect type. Expected "number".`** in the code editor once the form editor has rendered.

### Cause

`parseSchema` rewrites schemas for form display — notably forcing `num/amount` / `num/percent` refs to `type: "number"` so values right-align, even though GOBL serializes them as **strings**. It works on a shallow copy (`{ ...schema }`), so the nested `properties` / `items` objects it writes parsed children into are the *same objects* held by the shared `SchemaRegistry` cache. The display rewrites therefore leaked into the cache.

Before #240 this went unnoticed: Monaco fetched pristine schemas from gobl.org. Since #240, Monaco validates against the registry schemas — polluted ones, once the form editor had parsed a document.

### Fix

- `getSchema` parses a **deep clone** (`structuredClone`), so the registry always holds pristine schemas regardless of what the form parser rewrites.
- `loadSchemaSet` clones the schemas it returns, so Monaco's snapshot can never share mutable objects with the form parser (belt and braces against future mutation paths).

All registry writes are confined to `schema.ts`, and the only external entry into the parse pipeline (`getUIModel` → `getRootSchema` → `getSchema`) goes through the cloning path; `generateCorrectOptionsModel` parses API-provided objects, not registry ones.

## Testing

- `npm run check` — 0 errors, 0 warnings.
- `npm run lint` and `npm run build:package` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)